### PR TITLE
feat(llm): implement ConversationEngine with history management

### DIFF
--- a/docs/issues/003-llm-provider-setup.md
+++ b/docs/issues/003-llm-provider-setup.md
@@ -21,38 +21,45 @@ The conversation engine is the brain of the agent — it processes transcribed s
 
 ## Remaining Tasks
 
-- [ ] Create `ConversationEngine` class in `llm/conversation.py`
-  - [ ] `__init__(self, settings: Settings)` — initialize LLM via `get_llm()`, load system prompt
-  - [ ] `async def process_transcript(self, text: str) -> str` — add user message, invoke LLM, return response
-  - [ ] `def reset(self)` — clear conversation history
-  - [ ] Manage conversation history as a list of LangChain messages
-  - [ ] Truncate history when it exceeds context window limits
-- [ ] Wire `ConversationEngine` into `conversation_stage()` — read from in_queue, call `process_transcript`, push to out_queue
-- [ ] Add `{bot_name}` placeholder to `SYSTEM_PROMPT` (use `bot_name` from Settings)
-- [ ] Add tests for `ConversationEngine` (mocked LLM):
-  - [ ] `process_transcript` returns a string response
-  - [ ] Conversation history accumulates messages
-  - [ ] `reset()` clears history
-  - [ ] System prompt is included in first LLM call
+- [x] Create `ConversationEngine` class in `llm/conversation.py`
+  - [x] `__init__(self, settings: Settings)` — initialize LLM via `get_llm()`, load system prompt
+  - [x] `async def process_transcript(self, text: str) -> str` — add user message, invoke LLM, return response
+  - [x] `def reset(self)` — clear conversation history
+  - [x] Manage conversation history as a list of LangChain messages (`SystemMessage`, `HumanMessage`, `AIMessage`)
+  - [x] Truncate history when it exceeds `llm_max_history_messages` (keeps system message + last N)
+- [x] Wire `ConversationEngine` into `conversation_stage()` — read from in_queue, call `process_transcript`, push to out_queue
+- [x] Add `{bot_name}` placeholder to `SYSTEM_PROMPT` (use `bot_name` from Settings)
+- [x] Pass `llm_temperature` through `get_llm()` to all provider constructors
+- [x] Add `llm_max_history_messages` field to Settings (default: 20)
+- [x] Add tests for `ConversationEngine` (mocked LLM):
+  - [x] `process_transcript` returns a string response
+  - [x] Conversation history accumulates messages
+  - [x] `reset()` clears history
+  - [x] System prompt includes bot_name
+  - [x] History truncation respects max limit
+  - [x] `conversation_stage()` reads from in_queue and writes to out_queue
+  - [x] Stage continues processing after LLM errors
 
 ## Acceptance Criteria
 
-- [ ] `ConversationEngine` can be instantiated with mocked settings
-- [ ] `process_transcript("hello")` returns a non-empty string (mocked LLM)
-- [ ] Conversation history grows with each call
-- [ ] `reset()` clears history back to system prompt only
-- [ ] `conversation_stage()` reads from in_queue and writes to out_queue
-- [ ] `uv run ruff check src/ tests/` exits 0
-- [ ] `uv run mypy src/` exits 0 strict
-- [ ] All tests pass
+- [x] `ConversationEngine` can be instantiated with mocked settings
+- [x] `process_transcript("hello")` returns a non-empty string (mocked LLM)
+- [x] Conversation history grows with each call
+- [x] `reset()` clears history back to system prompt only
+- [x] `conversation_stage()` reads from in_queue and writes to out_queue
+- [x] `uv run ruff check src/ tests/` exits 0
+- [x] `uv run mypy src/` exits 0 strict
+- [x] All 29 tests pass
 
 ## Dependencies
 
 - 001 — Project Setup (done)
-- 002 — Config and Environment (needs `bot_name`, `llm_temperature`)
+- 002 — Config and Environment (done — `bot_name`, `llm_temperature`, `llm_max_history_messages`)
 
-## Files to Modify
+## Files Modified
 
-- `src/call_operator/llm/conversation.py`
-- `src/call_operator/prompts/conversation.py`
-- `tests/test_llm.py` (or new `tests/test_conversation.py`)
+- `src/call_operator/config.py` — added `llm_max_history_messages` field
+- `src/call_operator/llm/conversation.py` — implemented `ConversationEngine` class + wired `conversation_stage()`
+- `src/call_operator/llm/provider.py` — pass `temperature` to all provider constructors
+- `src/call_operator/prompts/conversation.py` — added `{bot_name}` placeholder to `SYSTEM_PROMPT`
+- `tests/test_conversation.py` — new file with 8 tests (engine + stage)

--- a/src/call_operator/config.py
+++ b/src/call_operator/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     llm_provider: str = "openai"
     llm_model: str = "gpt-4o"
     llm_temperature: float = 0.7
+    llm_max_history_messages: int = 20
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     google_api_key: str = ""

--- a/src/call_operator/llm/conversation.py
+++ b/src/call_operator/llm/conversation.py
@@ -5,13 +5,63 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from call_operator.llm.provider import get_llm
+from call_operator.prompts.conversation import SYSTEM_PROMPT
+
 if TYPE_CHECKING:
     import asyncio
+
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import BaseMessage
 
     from call_operator.config import Settings
     from call_operator.stt.base import Transcript
 
 logger = logging.getLogger(__name__)
+
+
+class ConversationEngine:
+    """Stateful conversation engine that manages history and generates responses."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._llm: BaseChatModel = get_llm(settings)
+        self._max_history: int = settings.llm_max_history_messages
+        system_content = SYSTEM_PROMPT.format(
+            bot_name=settings.bot_name,
+            context="",
+        )
+        self._system_message = SystemMessage(content=system_content)
+        self._history: list[BaseMessage] = [self._system_message]
+
+    @property
+    def history(self) -> list[BaseMessage]:
+        """Return the current conversation history (read-only view)."""
+        return list(self._history)
+
+    async def process_transcript(self, text: str) -> str:
+        """Add a user message, invoke the LLM, and return the response text."""
+        self._history.append(HumanMessage(content=text))
+
+        response = await self._llm.ainvoke(self._history)
+        response_text = str(response.content)
+
+        self._history.append(AIMessage(content=response_text))
+        self._truncate_history()
+
+        return response_text
+
+    def reset(self) -> None:
+        """Clear conversation history back to system prompt only."""
+        self._history = [self._system_message]
+
+    def _truncate_history(self) -> None:
+        """Keep system message + last N messages within the configured limit."""
+        # +1 accounts for the system message at index 0
+        max_len = self._max_history + 1
+        if len(self._history) > max_len:
+            self._history = [self._system_message] + self._history[-self._max_history :]
 
 
 async def conversation_stage(
@@ -25,13 +75,16 @@ async def conversation_stage(
     generates a response via the configured LLM, and pushes the response
     text to out_queue for TTS.
     """
-    # TODO: Initialize LLM via get_llm(settings)
-    # TODO: Load system prompt from prompts/conversation.py
-    # TODO: Maintain conversation history (list of messages)
-    # TODO: Read Transcript from in_queue
-    # TODO: Add user message to history
-    # TODO: Generate LLM response (async)
-    # TODO: Add assistant message to history
-    # TODO: Push response text to out_queue
-    # TODO: Manage context window (truncate old messages)
-    logger.warning("conversation_stage() is not yet implemented.")
+    engine = ConversationEngine(settings)
+
+    while True:
+        transcript = await in_queue.get()
+        try:
+            logger.debug("Processing transcript: %s", transcript.text[:80])
+            response = await engine.process_transcript(transcript.text)
+            await out_queue.put(response)
+            logger.debug("Generated response: %s", response[:80])
+        except Exception:
+            logger.exception("Error in conversation stage")
+        finally:
+            in_queue.task_done()

--- a/src/call_operator/llm/provider.py
+++ b/src/call_operator/llm/provider.py
@@ -25,15 +25,27 @@ def get_llm(settings: Settings) -> BaseChatModel:
     if provider == "openai":
         from langchain_openai import ChatOpenAI
 
-        return ChatOpenAI(model=model, api_key=settings.openai_api_key)  # type: ignore[arg-type]
+        return ChatOpenAI(
+            model=model,
+            api_key=settings.openai_api_key,  # type: ignore[arg-type]
+            temperature=settings.llm_temperature,
+        )
     elif provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
 
-        return ChatAnthropic(model_name=model, api_key=settings.anthropic_api_key)  # type: ignore[arg-type,call-arg]
+        return ChatAnthropic(  # type: ignore[call-arg]
+            model_name=model,
+            api_key=settings.anthropic_api_key,  # type: ignore[arg-type]
+            temperature=settings.llm_temperature,
+        )
     elif provider == "google":
         from langchain_google_genai import ChatGoogleGenerativeAI
 
-        return ChatGoogleGenerativeAI(model=model, google_api_key=settings.google_api_key)
+        return ChatGoogleGenerativeAI(
+            model=model,
+            google_api_key=settings.google_api_key,
+            temperature=settings.llm_temperature,
+        )
     elif provider == "openrouter":
         from langchain_openai import ChatOpenAI
 
@@ -41,6 +53,7 @@ def get_llm(settings: Settings) -> BaseChatModel:
             model=model,
             api_key=settings.openrouter_api_key,  # type: ignore[arg-type]
             base_url="https://openrouter.ai/api/v1",
+            temperature=settings.llm_temperature,
         )
     else:
         msg = f"Unknown LLM provider: {provider}"

--- a/src/call_operator/prompts/conversation.py
+++ b/src/call_operator/prompts/conversation.py
@@ -1,8 +1,8 @@
 """Prompt templates for the conversation engine."""
 
 SYSTEM_PROMPT = """\
-You are an AI meeting participant. You are joining a live video call and \
-interacting with other participants in real time via voice.
+You are {bot_name}, an AI meeting participant. You are joining a live video call \
+and interacting with other participants in real time via voice.
 
 Guidelines:
 - Be concise — you are speaking, not writing. Keep responses short and natural.

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,131 @@
+"""Tests for ConversationEngine and conversation_stage."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from call_operator.llm.conversation import ConversationEngine, conversation_stage
+from call_operator.stt.base import Transcript
+
+
+@pytest.fixture
+def mock_llm() -> AsyncMock:
+    """A mocked LangChain chat model."""
+    llm = AsyncMock()
+    llm.ainvoke.return_value = MagicMock(content="I understand, let me help with that.")
+    return llm
+
+
+@pytest.fixture
+def engine(mock_settings: MagicMock, mock_llm: AsyncMock) -> ConversationEngine:
+    """A ConversationEngine with a mocked LLM."""
+    with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+        return ConversationEngine(mock_settings)
+
+
+class TestConversationEngine:
+    @pytest.mark.asyncio
+    async def test_process_transcript_returns_response(self, engine: ConversationEngine) -> None:
+        result = await engine.process_transcript("Hello everyone")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_history_accumulates_messages(self, engine: ConversationEngine) -> None:
+        await engine.process_transcript("First message")
+        await engine.process_transcript("Second message")
+        # System + Human + AI + Human + AI = 5
+        assert len(engine.history) == 5
+        assert isinstance(engine.history[0], SystemMessage)
+        assert isinstance(engine.history[1], HumanMessage)
+        assert isinstance(engine.history[2], AIMessage)
+        assert isinstance(engine.history[3], HumanMessage)
+        assert isinstance(engine.history[4], AIMessage)
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_history(self, engine: ConversationEngine) -> None:
+        await engine.process_transcript("Hello")
+        assert len(engine.history) > 1
+        engine.reset()
+        assert len(engine.history) == 1
+        assert isinstance(engine.history[0], SystemMessage)
+
+    def test_system_prompt_includes_bot_name(self, engine: ConversationEngine) -> None:
+        system_msg = engine.history[0]
+        assert "AI Assistant" in str(system_msg.content)
+
+    @pytest.mark.asyncio
+    async def test_history_truncation(self, mock_llm: AsyncMock) -> None:
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LLM_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "test-key",
+                    "LLM_MAX_HISTORY_MESSAGES": "4",
+                },
+            ),
+            patch("call_operator.llm.conversation.get_llm", return_value=mock_llm),
+        ):
+            from call_operator.config import Settings
+
+            settings = Settings()
+            eng = ConversationEngine(settings)
+
+            # Send 5 exchanges (10 messages) — should truncate to system + 4
+            for i in range(5):
+                await eng.process_transcript(f"Message {i}")
+
+            assert len(eng.history) == 5  # system + 4 recent messages
+            assert isinstance(eng.history[0], SystemMessage)
+
+    @pytest.mark.asyncio
+    async def test_llm_ainvoke_is_called(
+        self, engine: ConversationEngine, mock_llm: AsyncMock
+    ) -> None:
+        await engine.process_transcript("Hello")
+        mock_llm.ainvoke.assert_called_once()
+        # After processing, history should be: system + human + AI
+        assert len(engine.history) == 3
+        assert engine.history[1].content == "Hello"
+
+
+class TestConversationStage:
+    @pytest.mark.asyncio
+    async def test_reads_from_queue_and_writes_response(self, mock_settings: MagicMock) -> None:
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.return_value = MagicMock(content="Got it.")
+
+        in_queue: asyncio.Queue[Transcript] = asyncio.Queue()
+        out_queue: asyncio.Queue[str] = asyncio.Queue()
+
+        in_queue.put_nowait(Transcript(text="Hello", speaker="user1"))
+
+        with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+            task = asyncio.create_task(conversation_stage(in_queue, out_queue, mock_settings))
+            result = await asyncio.wait_for(out_queue.get(), timeout=2.0)
+            task.cancel()
+
+        assert result == "Got it."
+
+    @pytest.mark.asyncio
+    async def test_stage_continues_on_error(self, mock_settings: MagicMock) -> None:
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.side_effect = [RuntimeError("LLM error"), MagicMock(content="OK")]
+
+        in_queue: asyncio.Queue[Transcript] = asyncio.Queue()
+        out_queue: asyncio.Queue[str] = asyncio.Queue()
+
+        in_queue.put_nowait(Transcript(text="First", speaker="user1"))
+        in_queue.put_nowait(Transcript(text="Second", speaker="user1"))
+
+        with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+            task = asyncio.create_task(conversation_stage(in_queue, out_queue, mock_settings))
+            result = await asyncio.wait_for(out_queue.get(), timeout=2.0)
+            task.cancel()
+
+        assert result == "OK"


### PR DESCRIPTION
## Summary

- Implement `ConversationEngine` class with async LLM invocation, conversation history management, and configurable history truncation
- Wire `ConversationEngine` into `conversation_stage()` pipeline loop (reads `Transcript` from in_queue, generates response, pushes to out_queue)
- Pass `llm_temperature` through `get_llm()` to all provider constructors (OpenAI, Anthropic, Google, OpenRouter)

## Motivation

Resolves https://github.com/takeshi-su57/call-operator/issues/5

The conversation engine is the brain of the agent — it processes transcribed speech and generates responses. The pipeline stage needed a stateful engine to maintain conversation history across turns and manage the context window.

## Changes

- **`src/call_operator/llm/conversation.py`** — Added `ConversationEngine` class with:
  - `__init__()` — initializes LLM via `get_llm()`, builds system prompt with `bot_name`
  - `process_transcript()` — appends `HumanMessage`, calls `ainvoke()`, appends `AIMessage`, truncates history
  - `reset()` — clears history back to system prompt only
  - `_truncate_history()` — keeps system message + last N messages (configurable via `llm_max_history_messages`)
- **`src/call_operator/llm/conversation.py`** — Wired `conversation_stage()` with queue-based loop and error handling
- **`src/call_operator/llm/provider.py`** — Added `temperature=settings.llm_temperature` to all provider constructors
- **`src/call_operator/config.py`** — Added `llm_max_history_messages: int = 20` field
- **`src/call_operator/prompts/conversation.py`** — Added `{bot_name}` placeholder to `SYSTEM_PROMPT`
- **`tests/test_conversation.py`** — 8 new tests covering engine behavior and pipeline stage
- **`docs/issues/003-llm-provider-setup.md`** — Updated issue with completed status

## How to Test

1. Checkout this branch
2. Run `uv sync --all-extras`
3. Run `uv run pytest tests/test_conversation.py -v` — all 8 tests pass
4. Run `uv run ruff check src/ tests/` — exits 0
5. Run `uv run mypy src/` — exits 0 strict
6. Run `uv run pytest` — all 29 tests pass

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (8 new tests)
- [x] No new warnings or errors
- [x] Ruff lint + format clean
- [x] mypy strict passes
- [x] Updated issue documentation
