### PR TITLE
feat(stt): implement local speech-to-text using faster-whisper

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,7 @@ uv run playwright install chromium               # Install browser
 - `.claude/rules/gh-issue.md` — Issue title format, templates for bugs/features/chores
 - `.claude/rules/ai-framework.md` — Sync protocol, skill/rule design, maintenance
 - `.claude/rules/documentation.md` — Docs structure, ADR conventions
+- `.claude/rules/logging.md` — Logging standards, LLM call logging, pipeline stage logging
 
 ## Known Gaps
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,98 @@
+# Logging Rules
+
+Standards for logging across the call-operator pipeline, with specific guidance for LLM calls and provider interactions.
+
+## General
+
+- Use Python `logging` module — `logger = logging.getLogger(__name__)` in every module
+- Log level is configured via `LOG_LEVEL` env var (default `INFO`)
+- Never log API keys, tokens, or passwords at any level
+- Never log full transcript text or meeting audio at INFO level — use DEBUG
+- Safe to log at INFO: stage lifecycle (started/finished), latency metrics, error summaries
+
+## Pipeline Stage Logging
+
+Every pipeline stage must log:
+
+| Event | Level | What to include |
+|-------|-------|-----------------|
+| Stage started | INFO | Stage name, key config (e.g. threshold, model name) |
+| Stage finished | INFO | Chunks/items processed count, summary stats |
+| Item processed | DEBUG | Truncated content (first 80 chars max) |
+| Error (recoverable) | WARNING | Error type, context, stage continues |
+| Error (fatal) | ERROR | Full exception via `logger.exception()` |
+
+Example from `vad_stage`:
+```python
+logger.info("vad_stage started (threshold=%.2f)", threshold)
+logger.info("vad_stage finished — %d chunks, %d speech (%.1f%%)", ...)
+```
+
+## LLM Call Logging
+
+Every LLM invocation must log:
+
+### Before the call (DEBUG)
+- History size (number of messages)
+- Input text (truncated to 80 chars)
+
+### After the call (INFO)
+- **Latency** — wall-clock time in milliseconds
+- **Token usage** — input tokens, output tokens, total (from response metadata when available)
+- **Model name** — which model handled the request
+
+### After the call (DEBUG)
+- Response text (truncated to 80 chars)
+
+### On error (ERROR)
+- Full exception via `logger.exception()`
+- Provider name and model for debugging
+
+### Implementation pattern
+```python
+import time
+
+logger.debug("LLM call: history=%d messages, input=%s", len(history), text[:80])
+
+start = time.perf_counter()
+response = await self._llm.ainvoke(messages)
+latency_ms = (time.perf_counter() - start) * 1000
+
+# Extract token usage from response metadata (LangChain standard)
+usage = getattr(response, "usage_metadata", None)
+if usage:
+    logger.info(
+        "LLM response: %.0fms, tokens=%d/%d/%d (in/out/total), model=%s",
+        latency_ms, usage["input_tokens"], usage["output_tokens"],
+        usage["total_tokens"], self._model_name,
+    )
+else:
+    logger.info("LLM response: %.0fms, model=%s", latency_ms, self._model_name)
+
+logger.debug("LLM output: %s", str(response.content)[:80])
+```
+
+## STT / TTS Provider Logging
+
+- Log model loading time at INFO (e.g. "WhisperLocalSTT model loaded in 1200ms")
+- Log transcription latency at INFO (time spent in `asyncio.to_thread`)
+- Log audio buffer duration at DEBUG before each transcription
+- Log TTS synthesis latency at INFO
+- Never log raw audio bytes
+
+## LangChain Callbacks (Optional)
+
+For deeper observability, LangChain's callback system can be used:
+
+- Use `LangChainTracer` or a custom `BaseCallbackHandler` for structured traces
+- Callbacks are set per-call or globally — do NOT hardcode a tracing service
+- If LangGraph is adopted in the future, use its built-in step logging via callbacks
+
+## Anti-Patterns (Do NOT)
+
+- Log full conversation history at INFO — use DEBUG, and truncate
+- Log raw audio data or PCM bytes at any level
+- Use `print()` instead of `logging`
+- Log inside tight loops without rate-limiting (e.g. every audio chunk at INFO)
+- Embed provider-specific logging in the pipeline stages — keep it in the provider
+- Skip latency logging on LLM calls — this is critical for performance monitoring

--- a/docs/issues/006-stt-local.md
+++ b/docs/issues/006-stt-local.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Implement `WhisperLocalSTT` — a local speech-to-text provider using the `faster-whisper` library (CTranslate2-optimized Whisper). Define the base `STTProvider` abstract class. The provider buffers incoming audio chunks, runs transcription in a thread pool (to avoid blocking the async event loop), and yields `Transcript` objects with text, confidence, and timing.
+Implement `WhisperLocalSTT` — a local speech-to-text provider using the `faster-whisper` library (CTranslate2-optimized Whisper). Define the base `STTProvider` abstract class with a chunk-at-a-time interface. The provider buffers incoming audio chunks, runs transcription in a thread pool (to avoid blocking the async event loop), and returns `Transcript` objects with text, confidence, language, and timing.
 
 ## Motivation
 
@@ -10,36 +10,52 @@ Local STT provides zero-latency transcription without API costs or network depen
 
 ## Tasks
 
-- [ ] Create `src/call_operator/stt/__init__.py`
-- [ ] Create `src/call_operator/stt/base.py` with abstract `STTProvider` class
-- [ ] Define `Transcript` dataclass: `text` (str), `confidence` (float), `language` (str), `is_final` (bool), `timestamp` (float)
-- [ ] Define abstract methods: `async transcribe(chunk: AudioChunk) -> Transcript | None`, `async start()`, `async stop()`
-- [ ] Create `src/call_operator/stt/whisper_local.py` with `WhisperLocalSTT(STTProvider)`
-- [ ] Load faster-whisper `WhisperModel` with configurable model size (`WHISPER_MODEL_SIZE`) and compute type (int8 for CPU)
-- [ ] Implement audio buffering: accumulate chunks until a minimum duration (e.g., 1 second) before transcribing
-- [ ] Run `model.transcribe()` via `asyncio.to_thread()` to avoid blocking the event loop
-- [ ] Parse transcription result into `Transcript` object
-- [ ] Implement `stt_stage(input_queue: asyncio.Queue[AudioChunk], output_queue: asyncio.Queue[Transcript], provider: STTProvider) -> None`
-- [ ] The stage reads audio chunks, passes to provider, forwards non-empty transcripts
-- [ ] Handle end-of-stream: flush remaining buffer, transcribe final segment, propagate sentinel
-- [ ] Use `STT_LANGUAGE` from config for language hint
+- [x] Create `src/call_operator/stt/__init__.py` with `stt_stage()` pipeline function
+- [x] Revise `src/call_operator/stt/base.py` — chunk-at-a-time `STTProvider` interface (`start`, `transcribe`, `flush`, `stop`)
+- [x] Define `Transcript` dataclass: `text` (str), `speaker` (str|None), `confidence` (float), `language` (str), `is_final` (bool), `metadata` (dict), `timestamp` (float)
+- [x] Create `src/call_operator/stt/whisper_local.py` with `WhisperLocalSTT(STTProvider)`
+- [x] Load faster-whisper `WhisperModel` with configurable model size (`STT_MODEL`, default "tiny") and compute type (int8 for CPU)
+- [x] Implement audio buffering: accumulate chunks until minimum duration (1 second) before transcribing
+- [x] Run `model.transcribe()` via `asyncio.to_thread()` to avoid blocking the event loop
+- [x] Parse transcription result into `Transcript` object with confidence from `avg_logprob`
+- [x] Implement `stt_stage(in_queue, out_queue, provider)` pipeline function
+- [x] The stage reads audio chunks, passes to provider, forwards non-empty transcripts
+- [x] Handle end-of-stream: flush remaining buffer, transcribe final segment, propagate sentinel
+- [x] `WhisperLocalSTT` accepts `language` parameter (from `STT_LANGUAGE` config) as transcription hint
+- [x] Update `DeepgramSTT` stub to match new chunk-at-a-time interface
+- [x] Add logging rule (`.claude/rules/logging.md`) for LLM calls and pipeline stages
+- [x] Add comprehensive unit tests for `WhisperLocalSTT` and `stt_stage`
 
 ## Acceptance Criteria
 
-- [ ] `WhisperLocalSTT` loads the model and transcribes audio to text
-- [ ] Transcription runs in a background thread, not blocking the event loop
-- [ ] Audio is buffered to avoid transcribing tiny fragments
-- [ ] `Transcript` includes confidence score and timing
-- [ ] `stt_stage()` correctly bridges the audio queue to the transcript queue
-- [ ] End-of-stream flushes the buffer and transcribes remaining audio
-- [ ] All files pass `ruff check` and `mypy --strict`
+- [x] `WhisperLocalSTT` loads the model and transcribes audio to text
+- [x] Transcription runs in a background thread, not blocking the event loop
+- [x] Audio is buffered to avoid transcribing tiny fragments (1s minimum)
+- [x] `Transcript` includes confidence score, language, and timing
+- [x] `stt_stage()` correctly bridges the audio queue to the transcript queue
+- [x] End-of-stream flushes the buffer and transcribes remaining audio
+- [x] All files pass `ruff check` and `mypy --strict`
+- [x] 22 tests passing (10 unit + 6 stage integration + 6 existing)
+
+## Implementation Notes
+
+- **Interface change**: Replaced `transcribe_stream(AsyncIterator) -> AsyncIterator` with chunk-at-a-time `transcribe(chunk) -> Transcript | None`. This matches the queue-based pipeline pattern used by `vad_stage` and avoids iterator threading issues.
+- **`flush()` method**: Non-abstract with default `return None`. Providers override if they buffer audio (WhisperLocalSTT does, Deepgram may not need to).
+- **Confidence mapping**: `math.exp(avg_logprob)` clamped to [0.0, 1.0]. A logprob of 0.0 → 1.0 confidence; -1.0 → ~0.37.
+- **Duration fallback**: If `AudioChunk.duration_ms` is 0, computed from `len(data) / (2 * sample_rate) * 1000`.
+- **Config wiring**: `get_stt()` factory accepts `**kwargs` — pipeline caller passes `model=settings.stt_model, language=settings.stt_language`. Full pipeline wiring is deferred to pipeline.py implementation.
 
 ## Dependencies
 
 - 005 — VAD Integration (receives speech-only audio chunks)
 
-## Files to Create/Modify
+## Files Created/Modified
 
-- `src/call_operator/stt/__init__.py`
-- `src/call_operator/stt/base.py`
-- `src/call_operator/stt/whisper_local.py`
+- `src/call_operator/stt/__init__.py` — `stt_stage()` pipeline function
+- `src/call_operator/stt/base.py` — Revised `STTProvider` ABC + extended `Transcript`
+- `src/call_operator/stt/whisper_local.py` — Full `WhisperLocalSTT` implementation
+- `src/call_operator/stt/deepgram_cloud.py` — Updated stub for new interface
+- `tests/test_stt.py` — Extended with WhisperLocalSTT unit tests
+- `tests/test_stt_stage.py` — New: stt_stage integration tests
+- `.claude/rules/logging.md` — New: logging standards for pipeline and LLM calls
+- `.claude/CLAUDE.md` — Added logging rule reference

--- a/src/call_operator/stt/__init__.py
+++ b/src/call_operator/stt/__init__.py
@@ -1,1 +1,64 @@
-"""Speech-to-Text providers."""
+"""Speech-to-Text providers and pipeline stage."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from call_operator.stt.base import STTProvider, Transcript
+
+if TYPE_CHECKING:
+    import asyncio
+
+    from call_operator.adapters.base import AudioChunk
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["STTProvider", "Transcript", "stt_stage"]
+
+
+async def stt_stage(
+    in_queue: asyncio.Queue[AudioChunk | None],
+    out_queue: asyncio.Queue[Transcript | None],
+    provider: STTProvider,
+) -> None:
+    """Pipeline stage: convert speech audio chunks into transcripts.
+
+    Reads :class:`AudioChunk` objects from *in_queue*, passes each to
+    *provider.transcribe()*, and forwards non-``None`` results to
+    *out_queue*.  At end-of-stream (``None`` sentinel) the provider is
+    flushed so any remaining buffered audio is transcribed.
+    """
+    logger.info("stt_stage started")
+    await provider.start()
+
+    chunks_processed = 0
+    transcripts_produced = 0
+
+    try:
+        while True:
+            chunk = await in_queue.get()
+
+            # Sentinel — flush and exit
+            if chunk is None:
+                break
+
+            chunks_processed += 1
+            transcript = await provider.transcribe(chunk)
+            if transcript is not None:
+                transcripts_produced += 1
+                await out_queue.put(transcript)
+
+        # Flush remaining buffered audio
+        final = await provider.flush()
+        if final is not None:
+            transcripts_produced += 1
+            await out_queue.put(final)
+    finally:
+        await provider.stop()
+        await out_queue.put(None)
+        logger.info(
+            "stt_stage finished — %d chunks, %d transcripts",
+            chunks_processed,
+            transcripts_produced,
+        )

--- a/src/call_operator/stt/base.py
+++ b/src/call_operator/stt/base.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-
     from call_operator.adapters.base import AudioChunk
 
 
@@ -19,22 +17,42 @@ class Transcript:
     text: str
     speaker: str | None = None
     confidence: float = 0.0
+    language: str = ""
     is_final: bool = True
     metadata: dict[str, str] = field(default_factory=dict)
+    timestamp: float = 0.0
 
 
 class STTProvider(ABC):
-    """Interface for Speech-to-Text providers."""
+    """Interface for Speech-to-Text providers.
+
+    Lifecycle: ``start()`` → ``transcribe()`` (repeated) → ``flush()`` → ``stop()``.
+    """
 
     @abstractmethod
-    def transcribe_stream(
-        self,
-        audio_stream: AsyncIterator[AudioChunk],
-    ) -> AsyncIterator[Transcript]:
-        """Transcribe a stream of audio chunks into text.
+    async def start(self) -> None:
+        """Initialize resources (e.g. load model, open connection)."""
+        ...
 
-        Yields Transcript objects as speech is recognized.
+    @abstractmethod
+    async def transcribe(self, chunk: AudioChunk) -> Transcript | None:
+        """Process one audio chunk.
+
+        Returns a :class:`Transcript` when enough audio has been buffered,
+        or ``None`` if still accumulating.
         """
+        ...
+
+    async def flush(self) -> Transcript | None:
+        """Transcribe any remaining buffered audio.
+
+        Called at end-of-stream. Default returns ``None`` (no buffering).
+        """
+        return None
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Release resources."""
         ...
 
 

--- a/src/call_operator/stt/deepgram_cloud.py
+++ b/src/call_operator/stt/deepgram_cloud.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING
 from call_operator.stt.base import STTProvider, Transcript
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-
     from call_operator.adapters.base import AudioChunk
 
 logger = logging.getLogger(__name__)
@@ -22,15 +20,18 @@ class DeepgramSTT(STTProvider):
         self.api_key = api_key
         self.model = model
 
-    async def transcribe_stream(
-        self,
-        audio_stream: AsyncIterator[AudioChunk],
-    ) -> AsyncIterator[Transcript]:
-        """Transcribe audio via Deepgram's streaming WebSocket API."""
+    async def start(self) -> None:
+        """Open WebSocket connection to Deepgram."""
         # TODO: Open WebSocket connection to Deepgram
-        # TODO: Stream audio chunks to the WebSocket
-        # TODO: Receive transcription results
-        # TODO: Yield Transcript objects (interim + final)
-        logger.warning("DeepgramSTT.transcribe_stream() is not yet implemented.")
-        return
-        yield  # Make this an async generator
+        logger.warning("DeepgramSTT.start() is not yet implemented.")
+
+    async def transcribe(self, chunk: AudioChunk) -> Transcript | None:
+        """Stream an audio chunk to Deepgram and return any result."""
+        # TODO: Send audio chunk via WebSocket, receive transcription
+        logger.warning("DeepgramSTT.transcribe() is not yet implemented.")
+        return None
+
+    async def stop(self) -> None:
+        """Close WebSocket connection."""
+        # TODO: Close WebSocket connection
+        logger.warning("DeepgramSTT.stop() is not yet implemented.")

--- a/src/call_operator/stt/whisper_local.py
+++ b/src/call_operator/stt/whisper_local.py
@@ -2,38 +2,146 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import TYPE_CHECKING
+import math
+import time
+from typing import TYPE_CHECKING, Any
 
 from call_operator.stt.base import STTProvider, Transcript
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    import numpy as np
+    from faster_whisper import WhisperModel
 
     from call_operator.adapters.base import AudioChunk
 
 logger = logging.getLogger(__name__)
 
+# Minimum buffered audio duration before running transcription.
+_MIN_BUFFER_MS = 1000.0
+
 
 class WhisperLocalSTT(STTProvider):
     """faster-whisper based STT — runs locally on CPU.
 
-    Uses the 'tiny' or 'base' model by default for low latency.
+    Audio chunks are buffered until at least :data:`_MIN_BUFFER_MS` of audio
+    has accumulated, then transcription is run in a background thread via
+    :func:`asyncio.to_thread` to avoid blocking the event loop.
     """
 
-    def __init__(self, model: str = "tiny", **kwargs: str) -> None:
+    def __init__(self, model: str = "tiny", language: str = "en", **kwargs: str) -> None:
         self.model_name = model
-        self._model = None  # Lazy-loaded
+        self.language = language
+        self._model: WhisperModel | None = None
+        self._buffer: list[bytes] = []
+        self._buffer_duration_ms: float = 0.0
+        self._sample_rate: int = 16000
 
-    async def transcribe_stream(
-        self,
-        audio_stream: AsyncIterator[AudioChunk],
-    ) -> AsyncIterator[Transcript]:
-        """Transcribe audio chunks using faster-whisper."""
-        # TODO: Load faster-whisper model (lazy, first call)
-        # TODO: Buffer audio chunks into segments
-        # TODO: Run transcription via asyncio.to_thread() (CPU-bound)
-        # TODO: Yield Transcript objects
-        logger.warning("WhisperLocalSTT.transcribe_stream() is not yet implemented.")
-        return
-        yield  # Make this an async generator
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Load the faster-whisper model in a background thread."""
+        if self._model is not None:
+            return
+        self._model = await asyncio.to_thread(self._load_model)
+        logger.info(
+            "WhisperLocalSTT model loaded (model=%s, language=%s)",
+            self.model_name,
+            self.language,
+        )
+
+    def _load_model(self) -> WhisperModel:
+        from faster_whisper import WhisperModel as _WhisperModel
+
+        return _WhisperModel(self.model_name, device="cpu", compute_type="int8")
+
+    async def stop(self) -> None:
+        """Release model and clear buffers."""
+        self._model = None
+        self._buffer.clear()
+        self._buffer_duration_ms = 0.0
+        logger.info("WhisperLocalSTT stopped")
+
+    # ------------------------------------------------------------------
+    # Transcription
+    # ------------------------------------------------------------------
+
+    async def transcribe(self, chunk: AudioChunk) -> Transcript | None:
+        """Buffer *chunk* and transcribe when enough audio has accumulated."""
+        if self._model is None:
+            await self.start()
+
+        self._buffer.append(chunk.data)
+        self._buffer_duration_ms += self._chunk_duration_ms(chunk)
+
+        if self._buffer_duration_ms < _MIN_BUFFER_MS:
+            return None
+
+        return await self._run_transcription()
+
+    async def flush(self) -> Transcript | None:
+        """Transcribe whatever audio remains in the buffer."""
+        if not self._buffer:
+            return None
+        return await self._run_transcription()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _run_transcription(self) -> Transcript | None:
+        """Concatenate buffer, run Whisper in a thread, return result."""
+        import numpy as _np
+
+        audio_bytes = b"".join(self._buffer)
+        self._buffer.clear()
+        self._buffer_duration_ms = 0.0
+
+        audio_array = _np.frombuffer(audio_bytes, dtype=_np.int16).astype(_np.float32) / 32768.0
+
+        segments, info = await asyncio.to_thread(self._transcribe_sync, audio_array)
+
+        if not segments:
+            return None
+
+        text_parts: list[str] = []
+        logprob_sum = 0.0
+        for seg in segments:
+            text_parts.append(seg.text)
+            logprob_sum += seg.avg_logprob
+
+        combined_text = " ".join(text_parts).strip()
+        if not combined_text:
+            return None
+
+        avg_logprob = logprob_sum / len(segments)
+        confidence = min(max(math.exp(avg_logprob), 0.0), 1.0)
+
+        return Transcript(
+            text=combined_text,
+            confidence=confidence,
+            language=info.language,
+            is_final=True,
+            timestamp=time.time(),
+        )
+
+    def _transcribe_sync(self, audio: np.ndarray) -> tuple[list[Any], Any]:
+        """Run transcription synchronously (called via :func:`asyncio.to_thread`).
+
+        Both ``model.transcribe()`` and segment iteration happen in the same
+        thread because the segment generator is tied to the CTranslate2 context.
+        """
+        assert self._model is not None  # noqa: S101
+        segments_gen, info = self._model.transcribe(audio, language=self.language)
+        return list(segments_gen), info
+
+    @staticmethod
+    def _chunk_duration_ms(chunk: AudioChunk) -> float:
+        """Return chunk duration in milliseconds."""
+        if chunk.duration_ms > 0:
+            return chunk.duration_ms
+        # 2 bytes per sample for 16-bit PCM mono
+        return len(chunk.data) / (2 * chunk.sample_rate) * 1000

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -1,12 +1,20 @@
-"""Tests for STT provider factory."""
+"""Tests for STT provider factory, Transcript, and WhisperLocalSTT."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from call_operator.adapters.base import AudioChunk
 from call_operator.stt.base import Transcript, get_stt
 from call_operator.stt.deepgram_cloud import DeepgramSTT
 from call_operator.stt.whisper_local import WhisperLocalSTT
+
+# ------------------------------------------------------------------
+# Factory
+# ------------------------------------------------------------------
 
 
 class TestSTTFactory:
@@ -23,6 +31,11 @@ class TestSTTFactory:
             get_stt("unknown_provider")
 
 
+# ------------------------------------------------------------------
+# Transcript
+# ------------------------------------------------------------------
+
+
 class TestTranscript:
     def test_default_values(self) -> None:
         t = Transcript(text="hello")
@@ -30,3 +43,172 @@ class TestTranscript:
         assert t.speaker is None
         assert t.confidence == 0.0
         assert t.is_final is True
+
+    def test_language_default(self) -> None:
+        t = Transcript(text="hi")
+        assert t.language == ""
+
+    def test_timestamp_default(self) -> None:
+        t = Transcript(text="hi")
+        assert t.timestamp == 0.0
+
+    def test_all_fields(self) -> None:
+        t = Transcript(
+            text="hello",
+            speaker="alice",
+            confidence=0.9,
+            language="en",
+            is_final=True,
+            metadata={"key": "val"},
+            timestamp=12345.0,
+        )
+        assert t.text == "hello"
+        assert t.speaker == "alice"
+        assert t.confidence == 0.9
+        assert t.language == "en"
+        assert t.is_final is True
+        assert t.metadata == {"key": "val"}
+        assert t.timestamp == 12345.0
+
+
+# ------------------------------------------------------------------
+# WhisperLocalSTT
+# ------------------------------------------------------------------
+
+
+def _make_chunk(duration_ms: float = 32.0, sample_rate: int = 16000) -> AudioChunk:
+    """Create a chunk with the correct byte count for the given duration."""
+    num_samples = int(sample_rate * duration_ms / 1000)
+    return AudioChunk(
+        data=b"\x00" * (num_samples * 2),
+        sample_rate=sample_rate,
+        channels=1,
+        timestamp=0.0,
+        duration_ms=duration_ms,
+    )
+
+
+def _fake_segment(text: str = "hello", avg_logprob: float = -0.3) -> SimpleNamespace:
+    return SimpleNamespace(text=text, avg_logprob=avg_logprob)
+
+
+def _fake_info(language: str = "en") -> SimpleNamespace:
+    return SimpleNamespace(language=language)
+
+
+class TestWhisperLocalSTT:
+    @pytest.mark.asyncio
+    async def test_start_loads_model(self) -> None:
+        stt = WhisperLocalSTT(model="tiny", language="en")
+        mock_model = MagicMock()
+
+        with patch.object(stt, "_load_model", return_value=mock_model):
+            await stt.start()
+
+        assert stt._model is mock_model
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self) -> None:
+        stt = WhisperLocalSTT()
+        stt._model = MagicMock()  # already loaded
+
+        with patch.object(stt, "_load_model") as mock_load:
+            await stt.start()
+
+        mock_load.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_buffers_until_min_duration(self) -> None:
+        stt = WhisperLocalSTT()
+        stt._model = MagicMock()
+
+        # 32ms chunk — well below the 1000ms minimum
+        chunk = _make_chunk(duration_ms=32.0)
+        result = await stt.transcribe(chunk)
+        assert result is None
+        assert stt._buffer_duration_ms == pytest.approx(32.0)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_runs_when_buffer_full(self) -> None:
+        stt = WhisperLocalSTT()
+        mock_model = MagicMock()
+        segments = [_fake_segment("hello world")]
+        info = _fake_info("en")
+        mock_model.transcribe.return_value = (iter(segments), info)
+        stt._model = mock_model
+
+        # Feed a single large chunk (1100ms)
+        chunk = _make_chunk(duration_ms=1100.0)
+        result = await stt.transcribe(chunk)
+
+        assert result is not None
+        assert result.text == "hello world"
+        assert result.language == "en"
+        assert result.is_final is True
+        assert result.confidence > 0.0
+        assert result.timestamp > 0.0
+
+    @pytest.mark.asyncio
+    async def test_transcribe_returns_none_for_empty_segments(self) -> None:
+        stt = WhisperLocalSTT()
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = (iter([]), _fake_info())
+        stt._model = mock_model
+
+        chunk = _make_chunk(duration_ms=1100.0)
+        result = await stt.transcribe(chunk)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_flush_transcribes_remaining_buffer(self) -> None:
+        stt = WhisperLocalSTT()
+        mock_model = MagicMock()
+        segments = [_fake_segment("final words")]
+        mock_model.transcribe.return_value = (iter(segments), _fake_info())
+        stt._model = mock_model
+
+        # Buffer a small chunk (below threshold)
+        chunk = _make_chunk(duration_ms=200.0)
+        await stt.transcribe(chunk)
+        assert stt._buffer  # still buffered
+
+        result = await stt.flush()
+        assert result is not None
+        assert result.text == "final words"
+        assert not stt._buffer
+
+    @pytest.mark.asyncio
+    async def test_flush_returns_none_when_empty(self) -> None:
+        stt = WhisperLocalSTT()
+        stt._model = MagicMock()
+        result = await stt.flush()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_state(self) -> None:
+        stt = WhisperLocalSTT()
+        stt._model = MagicMock()
+        stt._buffer = [b"\x00" * 100]
+        stt._buffer_duration_ms = 500.0
+
+        await stt.stop()
+
+        assert stt._model is None
+        assert stt._buffer == []
+        assert stt._buffer_duration_ms == 0.0
+
+    @pytest.mark.asyncio
+    async def test_chunk_duration_computed_from_data_length(self) -> None:
+        stt = WhisperLocalSTT()
+        stt._model = MagicMock()
+
+        # Chunk with duration_ms=0 — should compute from data length
+        chunk = AudioChunk(
+            data=b"\x00" * 3200,  # 1600 samples = 100ms at 16kHz
+            sample_rate=16000,
+            channels=1,
+            timestamp=0.0,
+            duration_ms=0.0,
+        )
+        await stt.transcribe(chunk)
+        assert stt._buffer_duration_ms == pytest.approx(100.0)

--- a/tests/test_stt_stage.py
+++ b/tests/test_stt_stage.py
@@ -1,0 +1,191 @@
+"""Tests for the stt_stage pipeline function."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from call_operator.adapters.base import AudioChunk
+from call_operator.stt import stt_stage
+from call_operator.stt.base import STTProvider, Transcript
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _make_chunk(duration_ms: float = 32.0) -> AudioChunk:
+    num_samples = int(16000 * duration_ms / 1000)
+    return AudioChunk(
+        data=b"\x00" * (num_samples * 2),
+        sample_rate=16000,
+        channels=1,
+        duration_ms=duration_ms,
+    )
+
+
+async def _collect(queue: asyncio.Queue[Transcript | None]) -> list[Transcript]:
+    """Drain non-None items from the queue until the sentinel."""
+    items: list[Transcript] = []
+    while True:
+        item = await asyncio.wait_for(queue.get(), timeout=2.0)
+        if item is None:
+            break
+        items.append(item)
+    return items
+
+
+# ------------------------------------------------------------------
+# Fake provider for testing
+# ------------------------------------------------------------------
+
+
+class FakeSTT(STTProvider):
+    """Deterministic STT provider for testing the stage wiring."""
+
+    def __init__(
+        self,
+        transcribe_results: list[Transcript | None] | None = None,
+        flush_result: Transcript | None = None,
+    ) -> None:
+        self.transcribe_results = list(transcribe_results or [])
+        self.flush_result = flush_result
+        self._call_index = 0
+        self.started = False
+        self.stopped = False
+        self.transcribe_calls = 0
+        self.flush_called = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def transcribe(self, chunk: AudioChunk) -> Transcript | None:
+        self.transcribe_calls += 1
+        if self._call_index < len(self.transcribe_results):
+            result = self.transcribe_results[self._call_index]
+            self._call_index += 1
+            return result
+        return None
+
+    async def flush(self) -> Transcript | None:
+        self.flush_called = True
+        return self.flush_result
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+class TestSttStage:
+    @pytest.mark.asyncio
+    async def test_forwards_transcripts(self) -> None:
+        t1 = Transcript(text="hello")
+        t2 = Transcript(text="world")
+        provider = FakeSTT(transcribe_results=[t1, t2])
+
+        in_q: asyncio.Queue[AudioChunk | None] = asyncio.Queue()
+        out_q: asyncio.Queue[Transcript | None] = asyncio.Queue()
+
+        await in_q.put(_make_chunk())
+        await in_q.put(_make_chunk())
+        await in_q.put(None)
+
+        await stt_stage(in_q, out_q, provider)
+        results = await _collect(out_q)
+
+        assert len(results) == 2
+        assert results[0].text == "hello"
+        assert results[1].text == "world"
+
+    @pytest.mark.asyncio
+    async def test_skips_none_results(self) -> None:
+        t1 = Transcript(text="only one")
+        provider = FakeSTT(transcribe_results=[None, t1, None])
+
+        in_q: asyncio.Queue[AudioChunk | None] = asyncio.Queue()
+        out_q: asyncio.Queue[Transcript | None] = asyncio.Queue()
+
+        await in_q.put(_make_chunk())
+        await in_q.put(_make_chunk())
+        await in_q.put(_make_chunk())
+        await in_q.put(None)
+
+        await stt_stage(in_q, out_q, provider)
+        results = await _collect(out_q)
+
+        assert len(results) == 1
+        assert results[0].text == "only one"
+
+    @pytest.mark.asyncio
+    async def test_propagates_sentinel(self) -> None:
+        provider = FakeSTT()
+
+        in_q: asyncio.Queue[AudioChunk | None] = asyncio.Queue()
+        out_q: asyncio.Queue[Transcript | None] = asyncio.Queue()
+
+        await in_q.put(_make_chunk())
+        await in_q.put(None)
+
+        await stt_stage(in_q, out_q, provider)
+
+        # The sentinel (None) must appear in the output
+        items: list[Transcript | None] = []
+        while not out_q.empty():
+            items.append(out_q.get_nowait())
+        assert None in items
+
+    @pytest.mark.asyncio
+    async def test_flushes_on_end_of_stream(self) -> None:
+        flush_transcript = Transcript(text="flushed")
+        provider = FakeSTT(flush_result=flush_transcript)
+
+        in_q: asyncio.Queue[AudioChunk | None] = asyncio.Queue()
+        out_q: asyncio.Queue[Transcript | None] = asyncio.Queue()
+
+        await in_q.put(_make_chunk())
+        await in_q.put(None)
+
+        await stt_stage(in_q, out_q, provider)
+
+        assert provider.flush_called
+        results = await _collect(out_q)
+        assert len(results) == 1
+        assert results[0].text == "flushed"
+
+    @pytest.mark.asyncio
+    async def test_calls_start_and_stop(self) -> None:
+        provider = FakeSTT()
+
+        in_q: asyncio.Queue[AudioChunk | None] = asyncio.Queue()
+        out_q: asyncio.Queue[Transcript | None] = asyncio.Queue()
+
+        await in_q.put(None)
+
+        await stt_stage(in_q, out_q, provider)
+
+        assert provider.started
+        assert provider.stopped
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self) -> None:
+        """Only a sentinel in — only a sentinel out, no transcripts."""
+        provider = FakeSTT()
+
+        in_q: asyncio.Queue[AudioChunk | None] = asyncio.Queue()
+        out_q: asyncio.Queue[Transcript | None] = asyncio.Queue()
+
+        await in_q.put(None)
+
+        await stt_stage(in_q, out_q, provider)
+
+        assert provider.transcribe_calls == 0
+        assert provider.flush_called
+        # Output should contain only the sentinel
+        item = out_q.get_nowait()
+        assert item is None
+        assert out_q.empty()


### PR DESCRIPTION
## Summary

- Implement `WhisperLocalSTT` provider using faster-whisper (CPU, int8) with audio buffering and thread-offloaded transcription
- Revise `STTProvider` base class from stream-based to chunk-at-a-time interface (`start`/`transcribe`/`flush`/`stop`)
- Add `stt_stage()` pipeline function bridging audio queue to transcript queue
- Add logging rule for consistent LLM call and pipeline stage logging

## Motivation

Resolves https://github.com/takeshi-su57/call-operator/issues/11

Local STT provides zero-latency transcription without API costs or network dependency. faster-whisper is 4x faster than OpenAI's Whisper with the same accuracy. This is the default STT provider for development and low-latency scenarios.

## Changes

### Core implementation
- **`src/call_operator/stt/base.py`** — Replaced `transcribe_stream(AsyncIterator)` with chunk-at-a-time API: `start()`, `transcribe(chunk) → Transcript | None`, `flush() → Transcript | None`, `stop()`. Extended `Transcript` with `language` and `timestamp` fields.
- **`src/call_operator/stt/whisper_local.py`** — Full implementation: model loading via `asyncio.to_thread()`, audio buffering (1s minimum before transcription), confidence scoring from `avg_logprob`, duration fallback when `AudioChunk.duration_ms` is 0.
- **`src/call_operator/stt/__init__.py`** — `stt_stage()` pipeline function following the `vad_stage` pattern: reads chunks → calls provider → forwards transcripts → flushes on sentinel.
- **`src/call_operator/stt/deepgram_cloud.py`** — Updated stub to conform to new interface.

### Tests (22 passing)
- **`tests/test_stt.py`** — Transcript fields, factory, WhisperLocalSTT buffering/transcription/flush/stop (10 new tests)
- **`tests/test_stt_stage.py`** — Stage wiring: forwards transcripts, skips None, propagates sentinel, flushes on end-of-stream, lifecycle calls (6 tests)

### Documentation
- **`.claude/rules/logging.md`** — New rule: logging standards for pipeline stages, LLM calls (latency, tokens, model), and providers
- **`docs/issues/006-stt-local.md`** — Updated with implementation notes and checked-off tasks

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Chunk-at-a-time over stream iterator | Matches queue-based pipeline pattern (like `vad_stage`). Avoids CTranslate2 generator crossing thread boundaries. |
| 1 second buffer minimum | Prevents transcribing tiny fragments which produces poor Whisper results |
| `flush()` as non-abstract with default `None` | Only providers that buffer need to override (Whisper does, Deepgram streaming may not) |
| `math.exp(avg_logprob)` for confidence | Maps Whisper's log-probability to 0–1 range. -0.3 → ~0.74, -1.0 → ~0.37 |

## How to Test

1. Checkout this branch
2. `uv sync --all-extras`
3. `uv run pytest tests/test_stt.py tests/test_stt_stage.py -v`
4. `uv run ruff check src/call_operator/stt/`
5. `uv run mypy src/call_operator/stt/`

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (22 passing, 68 total suite)
- [x] No new warnings or errors
- [x] `ruff check` passes
- [x] `mypy --strict` passes
- [x] Updated issue documentation
