### PR TITLE
feat(llm): implement full conversation engine with context summarization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@
 LLM_PROVIDER=openai              # openai | anthropic | google | openrouter
 LLM_MODEL=gpt-4o                 # Model name (provider-specific)
 LLM_TEMPERATURE=0.7              # LLM response temperature (0.0-2.0)
+LLM_MAX_HISTORY_MESSAGES=20       # Max conversation turns to keep
+LLM_MAX_CONTEXT_TOKENS=8000       # Approx token limit before summarization
+CONVERSATION_DEBOUNCE_MS=500       # Wait for more speech before responding (ms)
 
 # API Keys — provide the key for your chosen provider
 OPENAI_API_KEY=

--- a/docs/issues/009-conversation-engine.md
+++ b/docs/issues/009-conversation-engine.md
@@ -10,49 +10,88 @@ The conversation engine is the central intelligence of the meeting agent. It tra
 
 ## Tasks
 
-- [ ] Flesh out `src/call_operator/llm/conversation.py` — replace stub with full implementation
-- [ ] Implement `ConversationEngine.__init__()`: initialize LLM via `get_llm()`, load system prompt, create empty message history
-- [ ] Implement `async process_transcript(text: str) -> str`:
+- [x] Flesh out `src/call_operator/llm/conversation.py` — replace stub with full implementation
+- [x] Implement `ConversationEngine.__init__()`: initialize LLM via `get_llm()`, load system prompt, create empty message history
+- [x] Implement `async process_transcript(text: str) -> str`:
   - Add user message (transcribed speech) to history
   - Build messages list: system prompt + conversation history
   - Call LLM via `llm.ainvoke(messages)`
   - Add assistant response to history
   - Return response text
-- [ ] Implement context window management:
+- [x] Implement context window management:
   - Track token count (approximate via character count / 4)
   - When history exceeds `MAX_CONTEXT_TOKENS` (configurable, default 8000), summarize older messages and replace them
   - Always keep the system prompt and last N messages intact
-- [ ] Implement `reset()`: clear conversation history
-- [ ] Implement `get_history() -> list[dict]`: return conversation history for debugging
-- [ ] Update `src/call_operator/prompts/conversation.py`:
+- [x] Implement `reset()`: clear conversation history
+- [x] Implement `get_history() -> list[dict]`: return conversation history for debugging
+- [x] Update `src/call_operator/prompts/conversation.py`:
   - `SYSTEM_PROMPT`: template for meeting assistant behavior with `{bot_name}` placeholder
   - `SUMMARIZE_PROMPT`: template for summarizing older conversation history
-- [ ] Implement `conversation_stage(input_queue: asyncio.Queue[Transcript], output_queue: asyncio.Queue[str], engine: ConversationEngine) -> None`
+- [x] Implement `conversation_stage(input_queue: asyncio.Queue[Transcript | None], output_queue: asyncio.Queue[str | None], settings: Settings) -> None`
   - Read `Transcript` from input queue (only process `is_final=True`)
   - Skip empty or noise-only transcripts
   - Pass text to `engine.process_transcript()`
   - Put response text on output queue
-  - Handle end-of-stream sentinel
-- [ ] Add debouncing: wait briefly for additional transcript chunks before responding (avoid responding to partial sentences)
+  - Handle end-of-stream sentinel (`None` propagation)
+- [x] Add debouncing: wait briefly for additional transcript chunks before responding (avoid responding to partial sentences)
 
 ## Acceptance Criteria
 
-- [ ] `ConversationEngine` initializes with the configured LLM provider
-- [ ] `process_transcript()` sends messages to LLM and returns response text
-- [ ] Conversation history accumulates across multiple calls
-- [ ] Context window management prevents token overflow
-- [ ] `conversation_stage()` correctly bridges transcript queue to text output queue
-- [ ] Only final transcripts are processed (interim results are skipped)
-- [ ] System prompt includes `{bot_name}` and meeting-relevant instructions
-- [ ] `reset()` clears all history
-- [ ] All files pass `ruff check` and `mypy --strict`
+- [x] `ConversationEngine` initializes with the configured LLM provider
+- [x] `process_transcript()` sends messages to LLM and returns response text
+- [x] Conversation history accumulates across multiple calls
+- [x] Context window management prevents token overflow
+- [x] `conversation_stage()` correctly bridges transcript queue to text output queue
+- [x] Only final transcripts are processed (interim results are skipped)
+- [x] System prompt includes `{bot_name}` and meeting-relevant instructions
+- [x] `reset()` clears all history
+- [x] All files pass `ruff check` and `mypy --strict`
+
+## Implementation Notes
+
+### Context window summarization
+
+When `_estimate_tokens()` (char count / 4) exceeds `LLM_MAX_CONTEXT_TOKENS` (default 8000):
+1. Non-system messages are split at the midpoint
+2. Older half is serialized as "Role: content" lines
+3. A separate LLM call with `SUMMARIZE_PROMPT` produces a concise summary
+4. Older messages are replaced with a single `SystemMessage("Summary of earlier conversation:\n...")`
+5. Result: `[system_prompt, summary_msg, *newer_messages]`
+
+Simple truncation (`_truncate_history`, keeps system + last N messages) runs first as a fast guard.
+
+### Debouncing
+
+After receiving a final transcript, `conversation_stage` uses `asyncio.wait_for(in_queue.get(), timeout=debounce_s)` to collect additional transcripts within the debounce window (`CONVERSATION_DEBOUNCE_MS`, default 500ms). Collected texts are concatenated with spaces. If a sentinel arrives during debounce, accumulated text is processed before shutdown.
+
+### LLM call logging
+
+Per project logging rules: latency (ms), token usage (input/output/total from `response.usage_metadata`), and model name logged at INFO. Input/output text logged at DEBUG (truncated to 80 chars).
+
+### New config settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `LLM_MAX_CONTEXT_TOKENS` | 8000 | Approx token limit before summarization triggers |
+| `CONVERSATION_DEBOUNCE_MS` | 500 | Wait time (ms) to collect more speech before responding |
+
+### Testing
+
+- **Unit tests** (`tests/test_conversation.py`): 14 tests covering engine + stage behavior
+- Engine: process_transcript, history accumulation, reset, bot_name, truncation, ainvoke, get_history, summarization
+- Stage: queue bridging, error recovery, sentinel propagation, is_final filtering, empty filtering, debounce combining
 
 ## Dependencies
 
 - 003 — LLM Provider Setup (`get_llm()` factory and provider configuration)
 - 006 — STT Local (`Transcript` dataclass for input type)
 
-## Files to Create/Modify
+## Files Created/Modified
 
-- `src/call_operator/llm/conversation.py`
-- `src/call_operator/prompts/conversation.py`
+- `src/call_operator/llm/conversation.py` — full engine rewrite with summarization, logging, debounce
+- `src/call_operator/llm/__init__.py` — added exports
+- `src/call_operator/prompts/conversation.py` — added `SUMMARIZE_PROMPT`
+- `src/call_operator/config.py` — added `llm_max_context_tokens`, `conversation_debounce_ms`
+- `.env.example` — added new env vars
+- `tests/conftest.py` — added new settings to `mock_settings`
+- `tests/test_conversation.py` — expanded from 8 to 14 tests

--- a/src/call_operator/config.py
+++ b/src/call_operator/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
     llm_model: str = "gpt-4o"
     llm_temperature: float = 0.7
     llm_max_history_messages: int = 20
+    llm_max_context_tokens: int = 8000
+    conversation_debounce_ms: int = 500
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     google_api_key: str = ""

--- a/src/call_operator/llm/__init__.py
+++ b/src/call_operator/llm/__init__.py
@@ -1,1 +1,5 @@
 """LLM conversation engine."""
+
+from call_operator.llm.conversation import ConversationEngine, conversation_stage
+
+__all__ = ["ConversationEngine", "conversation_stage"]

--- a/src/call_operator/llm/conversation.py
+++ b/src/call_operator/llm/conversation.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from call_operator.llm.provider import get_llm
-from call_operator.prompts.conversation import SYSTEM_PROMPT
+from call_operator.prompts.conversation import SUMMARIZE_PROMPT, SYSTEM_PROMPT
 
 if TYPE_CHECKING:
-    import asyncio
-
     from langchain_core.language_models import BaseChatModel
     from langchain_core.messages import BaseMessage
 
@@ -27,7 +27,9 @@ class ConversationEngine:
 
     def __init__(self, settings: Settings) -> None:
         self._llm: BaseChatModel = get_llm(settings)
+        self._model_name: str = settings.llm_model
         self._max_history: int = settings.llm_max_history_messages
+        self._max_context_tokens: int = settings.llm_max_context_tokens
         system_content = SYSTEM_PROMPT.format(
             bot_name=settings.bot_name,
             context="",
@@ -40,15 +42,50 @@ class ConversationEngine:
         """Return the current conversation history (read-only view)."""
         return list(self._history)
 
+    def get_history(self) -> list[dict[str, str]]:
+        """Return conversation history as a list of dicts for debugging."""
+        result: list[dict[str, str]] = []
+        for msg in self._history:
+            if isinstance(msg, SystemMessage):
+                role = "system"
+            elif isinstance(msg, HumanMessage):
+                role = "human"
+            elif isinstance(msg, AIMessage):
+                role = "assistant"
+            else:
+                role = "unknown"
+            result.append({"role": role, "content": str(msg.content)})
+        return result
+
     async def process_transcript(self, text: str) -> str:
         """Add a user message, invoke the LLM, and return the response text."""
         self._history.append(HumanMessage(content=text))
 
+        logger.debug("LLM call: history=%d messages, input=%s", len(self._history), text[:80])
+
+        start = time.perf_counter()
         response = await self._llm.ainvoke(self._history)
+        latency_ms = (time.perf_counter() - start) * 1000
+
+        usage = getattr(response, "usage_metadata", None)
+        if isinstance(usage, dict):
+            logger.info(
+                "LLM response: %.0fms, tokens=%d/%d/%d (in/out/total), model=%s",
+                latency_ms,
+                usage.get("input_tokens", 0),
+                usage.get("output_tokens", 0),
+                usage.get("total_tokens", 0),
+                self._model_name,
+            )
+        else:
+            logger.info("LLM response: %.0fms, model=%s", latency_ms, self._model_name)
+
         response_text = str(response.content)
+        logger.debug("LLM output: %s", response_text[:80])
 
         self._history.append(AIMessage(content=response_text))
         self._truncate_history()
+        await self._maybe_summarize()
 
         return response_text
 
@@ -58,33 +95,112 @@ class ConversationEngine:
 
     def _truncate_history(self) -> None:
         """Keep system message + last N messages within the configured limit."""
-        # +1 accounts for the system message at index 0
         max_len = self._max_history + 1
         if len(self._history) > max_len:
             self._history = [self._system_message] + self._history[-self._max_history :]
 
+    def _estimate_tokens(self) -> int:
+        """Approximate token count of all messages via character count / 4."""
+        return sum(len(str(msg.content)) for msg in self._history) // 4
+
+    async def _maybe_summarize(self) -> None:
+        """If history exceeds token limit, summarize older messages."""
+        if self._estimate_tokens() <= self._max_context_tokens:
+            return
+
+        non_system = self._history[1:]
+        if len(non_system) <= 4:
+            return
+
+        split = len(non_system) // 2
+        older = non_system[:split]
+        newer = non_system[split:]
+
+        lines: list[str] = []
+        for msg in older:
+            role = "Assistant" if isinstance(msg, AIMessage) else "Participant"
+            lines.append(f"{role}: {msg.content}")
+        conversation_text = "\n".join(lines)
+
+        logger.debug("Summarizing %d older messages (%d chars)", len(older), len(conversation_text))
+
+        prompt = SUMMARIZE_PROMPT.format(conversation_history=conversation_text)
+
+        start = time.perf_counter()
+        summary_response = await self._llm.ainvoke([HumanMessage(content=prompt)])
+        latency_ms = (time.perf_counter() - start) * 1000
+        logger.info("Summarization: %.0fms, model=%s", latency_ms, self._model_name)
+
+        summary_text = str(summary_response.content)
+        summary_msg = SystemMessage(content=f"Summary of earlier conversation:\n{summary_text}")
+
+        self._history = [self._system_message, summary_msg, *newer]
+
 
 async def conversation_stage(
-    in_queue: asyncio.Queue[Transcript],
-    out_queue: asyncio.Queue[str],
+    in_queue: asyncio.Queue[Transcript | None],
+    out_queue: asyncio.Queue[str | None],
     settings: Settings,
 ) -> None:
     """Pipeline stage: process transcripts via LLM and generate responses.
 
-    Reads transcribed text from in_queue, maintains conversation history,
+    Reads transcribed text from *in_queue*, maintains conversation history,
     generates a response via the configured LLM, and pushes the response
-    text to out_queue for TTS.
+    text to *out_queue* for TTS.
     """
+    logger.info("conversation_stage started (model=%s)", settings.llm_model)
     engine = ConversationEngine(settings)
+    transcripts_processed = 0
+    debounce_s = settings.conversation_debounce_ms / 1000.0
 
-    while True:
-        transcript = await in_queue.get()
-        try:
-            logger.debug("Processing transcript: %s", transcript.text[:80])
-            response = await engine.process_transcript(transcript.text)
-            await out_queue.put(response)
-            logger.debug("Generated response: %s", response[:80])
-        except Exception:
-            logger.exception("Error in conversation stage")
-        finally:
-            in_queue.task_done()
+    try:
+        while True:
+            transcript = await in_queue.get()
+
+            if transcript is None:
+                break
+
+            if not transcript.is_final:
+                continue
+
+            text = transcript.text.strip()
+            if not text:
+                continue
+
+            # Debounce: collect additional transcripts within the window
+            combined = text
+            sentinel_received = False
+            while debounce_s > 0:
+                try:
+                    next_item = await asyncio.wait_for(in_queue.get(), timeout=debounce_s)
+                except TimeoutError:
+                    break
+
+                if next_item is None:
+                    sentinel_received = True
+                    break
+
+                if not next_item.is_final:
+                    continue
+                next_text = next_item.text.strip()
+                if next_text:
+                    combined = f"{combined} {next_text}"
+
+            # Process the (possibly combined) transcript
+            try:
+                logger.debug("Processing transcript: %s", combined[:80])
+                response = await engine.process_transcript(combined)
+                transcripts_processed += 1
+                await out_queue.put(response)
+                logger.debug("Generated response: %s", response[:80])
+            except Exception:  # noqa: BLE001
+                logger.exception("conversation_stage: LLM call failed, skipping")
+
+            if sentinel_received:
+                break
+    finally:
+        await out_queue.put(None)
+        logger.info(
+            "conversation_stage finished — %d transcripts processed",
+            transcripts_processed,
+        )

--- a/src/call_operator/prompts/conversation.py
+++ b/src/call_operator/prompts/conversation.py
@@ -24,3 +24,11 @@ The latest message from a participant:
 
 Generate a natural spoken response. Keep it brief (1-3 sentences).\
 """
+
+SUMMARIZE_PROMPT = """\
+The following is a transcript of earlier conversation in a meeting. \
+Summarize it in 2-4 sentences, preserving key decisions, action items, \
+and participant names. Be factual and concise.
+
+{conversation_history}\
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def mock_settings() -> Settings:
             "STT_MODEL": "tiny",
             "TTS_PROVIDER": "openai",
             "TTS_VOICE": "alloy",
+            "LLM_MAX_CONTEXT_TOKENS": "8000",
+            "CONVERSATION_DEBOUNCE_MS": "0",
             "BROWSER_HEADLESS": "true",
             "LOG_LEVEL": "DEBUG",
         },

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -27,14 +27,17 @@ def engine(mock_settings: MagicMock, mock_llm: AsyncMock) -> ConversationEngine:
         return ConversationEngine(mock_settings)
 
 
+# ------------------------------------------------------------------
+# ConversationEngine tests
+# ------------------------------------------------------------------
+
+
 class TestConversationEngine:
-    @pytest.mark.asyncio
     async def test_process_transcript_returns_response(self, engine: ConversationEngine) -> None:
         result = await engine.process_transcript("Hello everyone")
         assert isinstance(result, str)
         assert len(result) > 0
 
-    @pytest.mark.asyncio
     async def test_history_accumulates_messages(self, engine: ConversationEngine) -> None:
         await engine.process_transcript("First message")
         await engine.process_transcript("Second message")
@@ -46,7 +49,6 @@ class TestConversationEngine:
         assert isinstance(engine.history[3], HumanMessage)
         assert isinstance(engine.history[4], AIMessage)
 
-    @pytest.mark.asyncio
     async def test_reset_clears_history(self, engine: ConversationEngine) -> None:
         await engine.process_transcript("Hello")
         assert len(engine.history) > 1
@@ -58,7 +60,6 @@ class TestConversationEngine:
         system_msg = engine.history[0]
         assert "AI Assistant" in str(system_msg.content)
 
-    @pytest.mark.asyncio
     async def test_history_truncation(self, mock_llm: AsyncMock) -> None:
         with (
             patch.dict(
@@ -83,7 +84,6 @@ class TestConversationEngine:
             assert len(eng.history) == 5  # system + 4 recent messages
             assert isinstance(eng.history[0], SystemMessage)
 
-    @pytest.mark.asyncio
     async def test_llm_ainvoke_is_called(
         self, engine: ConversationEngine, mock_llm: AsyncMock
     ) -> None:
@@ -93,39 +93,180 @@ class TestConversationEngine:
         assert len(engine.history) == 3
         assert engine.history[1].content == "Hello"
 
+    async def test_get_history(self, engine: ConversationEngine) -> None:
+        await engine.process_transcript("Hello")
+        history = engine.get_history()
+        assert isinstance(history, list)
+        assert history[0]["role"] == "system"
+        assert history[1]["role"] == "human"
+        assert history[1]["content"] == "Hello"
+        assert history[2]["role"] == "assistant"
+
+    async def test_summarization_triggers_on_token_limit(self, mock_llm: AsyncMock) -> None:
+        mock_llm.ainvoke.side_effect = [
+            MagicMock(content="Response 1"),
+            MagicMock(content="Response 2"),
+            MagicMock(content="Response 3"),
+            MagicMock(content="Summary of the conversation."),  # summarization call
+            MagicMock(content="Response 4"),
+        ]
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LLM_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "test-key",
+                    "LLM_MAX_CONTEXT_TOKENS": "50",
+                },
+            ),
+            patch("call_operator.llm.conversation.get_llm", return_value=mock_llm),
+        ):
+            from call_operator.config import Settings
+
+            settings = Settings()
+            eng = ConversationEngine(settings)
+
+        await eng.process_transcript("A" * 100)
+        await eng.process_transcript("B" * 100)
+        await eng.process_transcript("C" * 100)
+
+        history = eng.get_history()
+        summary_found = any(
+            "Summary" in msg["content"] for msg in history if msg["role"] == "system"
+        )
+        assert summary_found
+
+
+# ------------------------------------------------------------------
+# conversation_stage tests
+# ------------------------------------------------------------------
+
 
 class TestConversationStage:
-    @pytest.mark.asyncio
     async def test_reads_from_queue_and_writes_response(self, mock_settings: MagicMock) -> None:
         mock_llm = AsyncMock()
         mock_llm.ainvoke.return_value = MagicMock(content="Got it.")
 
-        in_queue: asyncio.Queue[Transcript] = asyncio.Queue()
-        out_queue: asyncio.Queue[str] = asyncio.Queue()
+        in_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        out_queue: asyncio.Queue[str | None] = asyncio.Queue()
 
         in_queue.put_nowait(Transcript(text="Hello", speaker="user1"))
+        in_queue.put_nowait(None)
 
         with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
-            task = asyncio.create_task(conversation_stage(in_queue, out_queue, mock_settings))
-            result = await asyncio.wait_for(out_queue.get(), timeout=2.0)
-            task.cancel()
+            await conversation_stage(in_queue, out_queue, mock_settings)
 
+        result = out_queue.get_nowait()
         assert result == "Got it."
+        assert out_queue.get_nowait() is None
 
-    @pytest.mark.asyncio
     async def test_stage_continues_on_error(self, mock_settings: MagicMock) -> None:
         mock_llm = AsyncMock()
-        mock_llm.ainvoke.side_effect = [RuntimeError("LLM error"), MagicMock(content="OK")]
+        mock_llm.ainvoke.side_effect = [
+            RuntimeError("LLM error"),
+            MagicMock(content="OK"),
+        ]
 
-        in_queue: asyncio.Queue[Transcript] = asyncio.Queue()
-        out_queue: asyncio.Queue[str] = asyncio.Queue()
+        in_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        out_queue: asyncio.Queue[str | None] = asyncio.Queue()
 
         in_queue.put_nowait(Transcript(text="First", speaker="user1"))
         in_queue.put_nowait(Transcript(text="Second", speaker="user1"))
+        in_queue.put_nowait(None)
 
         with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
-            task = asyncio.create_task(conversation_stage(in_queue, out_queue, mock_settings))
-            result = await asyncio.wait_for(out_queue.get(), timeout=2.0)
-            task.cancel()
+            await conversation_stage(in_queue, out_queue, mock_settings)
 
+        result = out_queue.get_nowait()
         assert result == "OK"
+        assert out_queue.get_nowait() is None
+
+    async def test_sentinel_propagation(self, mock_settings: MagicMock) -> None:
+        in_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        out_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        in_queue.put_nowait(None)
+
+        with patch("call_operator.llm.conversation.get_llm", return_value=AsyncMock()):
+            await conversation_stage(in_queue, out_queue, mock_settings)
+
+        assert out_queue.get_nowait() is None
+
+    async def test_skips_non_final_transcripts(self, mock_settings: MagicMock) -> None:
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.return_value = MagicMock(content="Response")
+
+        in_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        out_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        in_queue.put_nowait(Transcript(text="interim", is_final=False))
+        in_queue.put_nowait(Transcript(text="final text", is_final=True))
+        in_queue.put_nowait(None)
+
+        with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+            await conversation_stage(in_queue, out_queue, mock_settings)
+
+        result = out_queue.get_nowait()
+        assert result == "Response"
+        mock_llm.ainvoke.assert_called_once()
+
+    async def test_skips_empty_transcripts(self, mock_settings: MagicMock) -> None:
+        mock_llm = AsyncMock()
+
+        in_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        out_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        in_queue.put_nowait(Transcript(text="   ", is_final=True))
+        in_queue.put_nowait(Transcript(text="", is_final=True))
+        in_queue.put_nowait(None)
+
+        with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+            await conversation_stage(in_queue, out_queue, mock_settings)
+
+        mock_llm.ainvoke.assert_not_called()
+        assert out_queue.get_nowait() is None
+
+    async def test_debounce_combines_transcripts(self) -> None:
+        captured_messages: list[list[object]] = []
+
+        async def capture_ainvoke(messages: list[object]) -> MagicMock:
+            # Snapshot the messages at call time (list is mutable)
+            captured_messages.append(list(messages))
+            return MagicMock(content="Combined response")
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.side_effect = capture_ainvoke
+
+        with patch.dict(
+            "os.environ",
+            {
+                "LLM_PROVIDER": "openai",
+                "OPENAI_API_KEY": "test-key",
+                "CONVERSATION_DEBOUNCE_MS": "200",
+            },
+        ):
+            from call_operator.config import Settings
+
+            settings = Settings()
+
+        in_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        out_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        # Both transcripts in queue before stage reads — will be combined
+        in_queue.put_nowait(Transcript(text="Hello", is_final=True))
+        in_queue.put_nowait(Transcript(text="everyone", is_final=True))
+        in_queue.put_nowait(None)
+
+        with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+            await conversation_stage(in_queue, out_queue, settings)
+
+        # LLM called once with combined text
+        assert len(captured_messages) == 1
+        messages = captured_messages[0]
+        human_msg = str(messages[-1].content)
+        assert human_msg == "Hello everyone"
+
+        result = out_queue.get_nowait()
+        assert result == "Combined response"
+        assert out_queue.get_nowait() is None


### PR DESCRIPTION
## Summary

- Implement full `ConversationEngine` with LLM call logging, token-based context summarization, and `get_history()` debugging method
- Rewrite `conversation_stage()` with sentinel-based shutdown, `is_final` filtering, empty transcript filtering, and debouncing
- Add `SUMMARIZE_PROMPT` template and two new config settings (`LLM_MAX_CONTEXT_TOKENS`, `CONVERSATION_DEBOUNCE_MS`)

## Motivation

Resolves https://github.com/takeshi-su57/call-operator/issues/17

## Changes

### ConversationEngine enhancements
- **LLM call logging**: latency (ms), token usage (in/out/total from `usage_metadata`), model name at INFO level; input/output text at DEBUG (truncated 80 chars)
- **Context summarization** (`_maybe_summarize`): when `_estimate_tokens()` (char count / 4) exceeds `LLM_MAX_CONTEXT_TOKENS`, older messages are summarized via a separate LLM call with `SUMMARIZE_PROMPT` and replaced with a single SystemMessage — keeps system prompt + summary + recent messages
- **`get_history() -> list[dict[str, str]]`**: serializes history as `[{"role": "system"|"human"|"assistant", "content": "..."}]` for debugging
- **`_truncate_history()`** retained as fast guard (system + last N messages)

### conversation_stage() rewrite
- **Sentinel support**: `None` → break + forward `None` to output queue (matches `stt_stage`/`tts_stage` pattern)
- **`is_final` filtering**: interim transcripts (`is_final=False`) are skipped
- **Empty filtering**: whitespace-only transcripts are skipped
- **Debouncing**: after receiving a final transcript, collects additional transcripts within `CONVERSATION_DEBOUNCE_MS` window (default 500ms) and concatenates them before processing
- **Error handling**: catches per-transcript exceptions, logs, and continues

### Config additions
| Setting | Default | Description |
|---------|---------|-------------|
| `LLM_MAX_CONTEXT_TOKENS` | 8000 | Approx token limit before summarization triggers |
| `CONVERSATION_DEBOUNCE_MS` | 500 | Wait time (ms) to collect more speech before responding |

### Other changes
- Added `SUMMARIZE_PROMPT` to `src/call_operator/prompts/conversation.py`
- Added exports to `src/call_operator/llm/__init__.py`
- Updated `.env.example` with new env vars
- Updated `tests/conftest.py` mock_settings with new fields (debounce set to 0 for fast tests)

## How to Test

### Unit tests (no API keys needed)
```bash
uv run pytest tests/test_conversation.py -v
```

14 tests: process_transcript, history accumulation, reset, bot_name, truncation, ainvoke, get_history, summarization trigger, queue bridging, error recovery, sentinel propagation, is_final filtering, empty filtering, debounce combining.

### Full suite
```bash
uv run pytest -v  # 112 passed, 7 skipped
```

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (8 → 14 tests)
- [x] No new warnings or errors
- [x] `ruff check` passes
- [x] `mypy --strict` passes
- [x] All 112 tests pass
- [x] Updated issue doc with implementation notes
