### PR TITLE
feat(resilience): add error handling, retry, and graceful degradation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,11 @@ AUDIO_CHUNK_MS=30                 # Audio chunk size in ms (VAD frame size)
 
 # --- Bot --------------------------------------------------------------------
 BOT_NAME=AI Assistant             # Display name in meetings
+
+# --- Resilience --------------------------------------------------------------
+RETRY_MAX_ATTEMPTS=3              # Max retry attempts for API calls
+RETRY_BASE_DELAY=1.0              # Base delay (seconds) for retry backoff
+RETRY_MAX_DELAY=30.0              # Maximum delay (seconds) for retry backoff
+CIRCUIT_BREAKER_THRESHOLD=5       # Consecutive failures to open circuit breaker
+CIRCUIT_BREAKER_COOLDOWN=60.0     # Seconds before retrying after circuit opens
+ADAPTER_MAX_RECONNECT_ATTEMPTS=3  # Max adapter reconnection attempts

--- a/docs/issues/013-error-handling.md
+++ b/docs/issues/013-error-handling.md
@@ -10,65 +10,134 @@ In a real meeting, the agent must be resilient. Network blips, API rate limits, 
 
 ## Tasks
 
-- [ ] Define custom exception hierarchy in `src/call_operator/exceptions.py`:
+- [x] Define custom exception hierarchy in `src/call_operator/exceptions.py`:
   - `CallOperatorError` (base)
   - `AdapterError`, `AdapterDisconnectedError`, `AdapterTimeoutError`
   - `STTError`, `STTProviderUnavailableError`
   - `TTSError`, `TTSProviderUnavailableError`
   - `LLMError`, `LLMProviderUnavailableError`
   - `PipelineError`, `PipelineShutdownError`
-- [ ] Implement retry decorator `async_retry(max_retries, base_delay, max_delay, exceptions)`:
-  - Exponential backoff with jitter
+- [x] Implement retry decorator `async_retry(max_retries, base_delay, max_delay, exceptions)`:
+  - Exponential backoff with jitter (`random.uniform(0.5, 1.5)`)
   - Configurable retryable exception types
-  - Logging on each retry attempt
-- [ ] Add reconnection logic to `GoogleMeetAdapter`:
-  - Detect disconnection (WebSocket close, page crash, removed from meeting)
-  - Attempt to rejoin the meeting automatically (up to 3 attempts)
-  - Emit events on reconnection success/failure
-- [ ] Add retry to LLM calls in `ConversationEngine.process_transcript()`:
-  - Retry on rate limit (429), server error (500+), and timeout
-  - Fall back to a shorter response on persistent failure ("I'm having trouble responding right now")
-- [ ] Add retry to cloud STT (`DeepgramSTT`):
-  - Reconnect WebSocket on disconnection
-  - Buffer audio during reconnection to avoid data loss
-  - Fall back to local Whisper if cloud STT is persistently unavailable
-- [ ] Add retry to TTS providers:
-  - Retry on API errors
-  - Fall back to a different TTS provider if the primary fails
-  - Fall back to text-only (log the response instead of speaking) as last resort
-- [ ] Add circuit breaker pattern for external APIs:
-  - After N consecutive failures, stop calling the API for a cooldown period
-  - Automatically retry after cooldown
-- [ ] Improve pipeline error handling:
-  - If a non-critical stage fails, continue with remaining stages
-  - If capture stage fails, attempt adapter reconnection before shutting down
-  - If conversation stage fails, log the error and skip the response (don't crash)
-- [ ] Add structured error logging: include stage name, error type, retry count, context
+  - Logging on each retry attempt (WARNING level)
+- [x] Add reconnection logic to `GoogleMeetAdapter`:
+  - Detect disconnection (page crash, evaluate error, meeting ended)
+  - `_reconnect()` method: disconnect + reconnect with exponential backoff (up to configurable attempts)
+  - Auto-reconnect in `read_audio()` on error, continue read loop on success
+  - Log reconnection attempts and success/failure
+- [x] Add retry to LLM calls in `ConversationEngine.process_transcript()`:
+  - Inline retry loop with exponential backoff + jitter
+  - Configurable via `RETRY_MAX_ATTEMPTS`, `RETRY_BASE_DELAY`, `RETRY_MAX_DELAY`
+  - Fall back to "I'm having trouble responding right now." on persistent failure
+  - Fallback message appended to history as AIMessage
+- [x] Add retry to cloud STT (`DeepgramSTT`):
+  - Existing reconnect logic enhanced with jitter on backoff delays
+  - `stt_stage` now wraps `provider.transcribe()` in try/except (was unprotected)
+  - Failed chunks are skipped, pipeline continues
+- [ ] Cloud STT fallback to local Whisper — **deferred**: requires `stt_stage` to hold a backup provider and swap at runtime (architectural change)
+- [x] Add retry to TTS providers:
+  - `_call_api_with_retry()` method added to all three providers (OpenAI, ElevenLabs, Google)
+  - 3 retries with exponential backoff per API call
+  - Raises `TTSError` after retries exhausted (caught by `tts_stage`)
+- [ ] TTS fallback to alternative provider — **deferred**: requires `tts_stage` to know about multiple providers (architectural change)
+- [x] Add circuit breaker pattern for external APIs:
+  - `CircuitBreaker` class: CLOSED → OPEN after N failures, OPEN → HALF_OPEN after cooldown, success → CLOSED
+  - Configurable via `CIRCUIT_BREAKER_THRESHOLD` and `CIRCUIT_BREAKER_COOLDOWN`
+  - **Note**: class is implemented and tested but not yet wired into provider call paths
+- [x] Improve pipeline error handling:
+  - `stt_stage`: per-chunk try/except added (was unprotected)
+  - `conversation_stage`: already had per-item error handling, now with retry before skip
+  - `tts_stage`: already had per-item error handling
+  - `_maybe_summarize()`: wrapped in try/except (summarization failure no longer crashes)
+  - Pipeline `run()`: structured error logging with exception type awareness (`AdapterError` vs `CallOperatorError` vs generic)
+- [x] Add structured error logging:
+  - Pipeline logs stage name + exception type + message
+  - Retry loops log attempt count, delay, and error
+  - Adapter reconnection logs attempt number and delay
 
 ## Acceptance Criteria
 
-- [ ] Custom exceptions provide clear error messages with context
-- [ ] API calls retry with exponential backoff on transient failures
-- [ ] Adapter reconnects automatically on disconnection
-- [ ] Pipeline continues operating when a single API call fails
-- [ ] Circuit breaker prevents hammering a failing API
-- [ ] TTS falls back to alternative provider on failure
-- [ ] Cloud STT falls back to local Whisper on persistent failure
-- [ ] All error paths are logged with structured context
-- [ ] No unhandled exceptions crash the pipeline
-- [ ] All files pass `ruff check` and `mypy --strict`
+- [x] Custom exceptions provide clear error messages with context
+- [x] API calls retry with exponential backoff on transient failures
+- [x] Adapter reconnects automatically on disconnection
+- [x] Pipeline continues operating when a single API call fails
+- [x] Circuit breaker prevents hammering a failing API (class implemented, not yet wired)
+- [ ] TTS falls back to alternative provider on failure — **deferred**
+- [ ] Cloud STT falls back to local Whisper on persistent failure — **deferred**
+- [x] All error paths are logged with structured context
+- [x] No unhandled exceptions crash the pipeline
+- [x] All files pass `ruff check` and `mypy --strict`
+
+## Implementation Notes
+
+### Exception hierarchy
+
+```
+CallOperatorError(Exception)
+├── AdapterError
+│   ├── AdapterDisconnectedError
+│   └── AdapterTimeoutError
+├── STTError
+│   └── STTProviderUnavailableError
+├── TTSError
+│   └── TTSProviderUnavailableError
+├── LLMError
+│   └── LLMProviderUnavailableError
+└── PipelineError
+    └── PipelineShutdownError
+```
+
+### Retry strategy
+
+All retry uses inline loops (not the decorator) in provider methods for simplicity with `self` parameter under mypy strict. The `async_retry` decorator is available in `retry.py` for standalone functions.
+
+Pattern: exponential backoff `min(base_delay * 2^attempt, max_delay)` with jitter `* random.uniform(0.5, 1.5)`.
+
+### Config additions
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `RETRY_MAX_ATTEMPTS` | 3 | Max retry attempts for API calls |
+| `RETRY_BASE_DELAY` | 1.0 | Base delay (seconds) for backoff |
+| `RETRY_MAX_DELAY` | 30.0 | Max delay (seconds) cap |
+| `CIRCUIT_BREAKER_THRESHOLD` | 5 | Consecutive failures to trip |
+| `CIRCUIT_BREAKER_COOLDOWN` | 60.0 | Seconds before half-open |
+| `ADAPTER_MAX_RECONNECT_ATTEMPTS` | 3 | Max adapter reconnect tries |
+
+### Deferred items
+
+Three items are deferred as they require architectural changes to stage functions:
+1. **TTS provider fallback** — `tts_stage` would need to hold multiple providers
+2. **STT cloud→local fallback** — `stt_stage` would need a backup provider
+3. **Circuit breaker integration** — providers would need to check `is_open` before calls
+
+The foundation (exception hierarchy, circuit breaker class, retry patterns) is in place for these.
+
+### Testing
+
+- **`tests/test_retry.py`** (NEW): 10 tests — async_retry (5) + CircuitBreaker (5)
+- **`tests/test_conversation.py`**: 3 new tests — retry then succeed, retry exhausted fallback, summarization error handling
+- **`tests/test_deepgram_cloud.py`**: updated backoff test for jitter ranges
 
 ## Dependencies
 
 - 010 — Async Pipeline (pipeline must be functional to add resilience)
 
-## Files to Create/Modify
+## Files Created/Modified
 
-- `src/call_operator/exceptions.py`
-- `src/call_operator/pipeline.py` (error handling in run loop)
-- `src/call_operator/adapters/google_meet.py` (reconnection)
-- `src/call_operator/stt/deepgram_cloud.py` (retry + fallback)
-- `src/call_operator/tts/openai_tts.py` (retry)
-- `src/call_operator/tts/elevenlabs_tts.py` (retry)
-- `src/call_operator/tts/google_tts.py` (retry)
-- `src/call_operator/llm/conversation.py` (retry)
+- `src/call_operator/exceptions.py` — NEW: 10 custom exception classes
+- `src/call_operator/retry.py` — NEW: `async_retry` decorator + `CircuitBreaker` class
+- `src/call_operator/config.py` — 6 new resilience settings
+- `.env.example` — resilience env vars section
+- `src/call_operator/llm/conversation.py` — LLM retry + fallback + summarization error handling
+- `src/call_operator/tts/openai_tts.py` — `_call_api_with_retry`, raises `TTSError`
+- `src/call_operator/tts/elevenlabs_tts.py` — same pattern
+- `src/call_operator/tts/google_tts.py` — same pattern
+- `src/call_operator/adapters/google_meet.py` — `_reconnect()`, auto-reconnect in `read_audio`
+- `src/call_operator/pipeline.py` — structured error logging with exception types
+- `src/call_operator/stt/__init__.py` — per-chunk try/except in `stt_stage`
+- `src/call_operator/stt/deepgram_cloud.py` — jitter in reconnect backoff
+- `tests/test_retry.py` — NEW: 10 tests
+- `tests/test_conversation.py` — 3 new retry/fallback tests
+- `tests/test_deepgram_cloud.py` — updated backoff test for jitter

--- a/src/call_operator/adapters/google_meet.py
+++ b/src/call_operator/adapters/google_meet.py
@@ -148,6 +148,8 @@ class GoogleMeetAdapter(MeetingAdapter):
         self._context: Any = None
         self._page: Any = None
         self._connected = False
+        self._url: str | None = None
+        self._max_reconnect_attempts: int = settings.adapter_max_reconnect_attempts
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -155,6 +157,8 @@ class GoogleMeetAdapter(MeetingAdapter):
 
     async def connect(self, url: str) -> None:
         """Join a Google Meet session via Playwright."""
+        self._url = url
+
         from playwright.async_api import async_playwright
 
         logger.info("Launching browser (headless=%s)", self.settings.browser_headless)
@@ -246,6 +250,8 @@ class GoogleMeetAdapter(MeetingAdapter):
             except Exception:  # noqa: BLE001
                 logger.warning("Error reading audio from browser", exc_info=True)
                 self._connected = False
+                if await self._reconnect():
+                    continue
                 return None
 
             if result and len(result) > 0:
@@ -322,6 +328,35 @@ class GoogleMeetAdapter(MeetingAdapter):
     # ------------------------------------------------------------------
     # Meeting state detection
     # ------------------------------------------------------------------
+
+    async def _reconnect(self) -> bool:
+        """Attempt to reconnect to the meeting. Returns True on success."""
+        if self._url is None:
+            return False
+
+        for attempt in range(self._max_reconnect_attempts):
+            delay = min(1.0 * (2**attempt), 10.0)
+            logger.warning(
+                "Adapter reconnecting (attempt %d/%d, delay=%.1fs)",
+                attempt + 1,
+                self._max_reconnect_attempts,
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+            try:
+                await self.disconnect()
+                await self.connect(self._url)
+                logger.info("Adapter reconnected successfully")
+                return True
+            except Exception:  # noqa: BLE001
+                logger.warning("Reconnect attempt %d failed", attempt + 1, exc_info=True)
+
+        logger.error(
+            "Adapter reconnection failed after %d attempts",
+            self._max_reconnect_attempts,
+        )
+        return False
 
     async def _check_meeting_ended(self) -> bool:
         """Check if the meeting has ended or user was removed."""

--- a/src/call_operator/config.py
+++ b/src/call_operator/config.py
@@ -56,6 +56,14 @@ class Settings(BaseSettings):
     # Bot
     bot_name: str = "AI Assistant"
 
+    # Resilience
+    retry_max_attempts: int = 3
+    retry_base_delay: float = 1.0
+    retry_max_delay: float = 30.0
+    circuit_breaker_threshold: int = 5
+    circuit_breaker_cooldown: float = 60.0
+    adapter_max_reconnect_attempts: int = 3
+
     @model_validator(mode="after")
     def _check_llm_api_key(self) -> Settings:
         provider_key_map: dict[str, str] = {

--- a/src/call_operator/exceptions.py
+++ b/src/call_operator/exceptions.py
@@ -1,0 +1,66 @@
+"""Custom exception hierarchy for call-operator."""
+
+from __future__ import annotations
+
+
+class CallOperatorError(Exception):
+    """Base exception for all call-operator errors."""
+
+
+# -- Adapter errors -----------------------------------------------------------
+
+
+class AdapterError(CallOperatorError):
+    """Error originating from a meeting adapter."""
+
+
+class AdapterDisconnectedError(AdapterError):
+    """The adapter lost its connection to the meeting."""
+
+
+class AdapterTimeoutError(AdapterError):
+    """An adapter operation timed out."""
+
+
+# -- STT errors ---------------------------------------------------------------
+
+
+class STTError(CallOperatorError):
+    """Error originating from a speech-to-text provider."""
+
+
+class STTProviderUnavailableError(STTError):
+    """The STT provider is unreachable after retries."""
+
+
+# -- TTS errors ---------------------------------------------------------------
+
+
+class TTSError(CallOperatorError):
+    """Error originating from a text-to-speech provider."""
+
+
+class TTSProviderUnavailableError(TTSError):
+    """The TTS provider is unreachable after retries."""
+
+
+# -- LLM errors ---------------------------------------------------------------
+
+
+class LLMError(CallOperatorError):
+    """Error originating from an LLM provider."""
+
+
+class LLMProviderUnavailableError(LLMError):
+    """The LLM provider is unreachable after retries."""
+
+
+# -- Pipeline errors ----------------------------------------------------------
+
+
+class PipelineError(CallOperatorError):
+    """Error in pipeline orchestration."""
+
+
+class PipelineShutdownError(PipelineError):
+    """The pipeline is shutting down."""

--- a/src/call_operator/llm/conversation.py
+++ b/src/call_operator/llm/conversation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import time
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_FALLBACK_RESPONSE = "I'm having trouble responding right now."
+
 
 class ConversationEngine:
     """Stateful conversation engine that manages history and generates responses."""
@@ -30,6 +33,9 @@ class ConversationEngine:
         self._model_name: str = settings.llm_model
         self._max_history: int = settings.llm_max_history_messages
         self._max_context_tokens: int = settings.llm_max_context_tokens
+        self._max_retries: int = settings.retry_max_attempts
+        self._retry_base_delay: float = settings.retry_base_delay
+        self._retry_max_delay: float = settings.retry_max_delay
         system_content = SYSTEM_PROMPT.format(
             bot_name=settings.bot_name,
             context="",
@@ -64,7 +70,32 @@ class ConversationEngine:
         logger.debug("LLM call: history=%d messages, input=%s", len(self._history), text[:80])
 
         start = time.perf_counter()
-        response = await self._llm.ainvoke(self._history)
+        response = None
+        last_exc: Exception | None = None
+
+        for attempt in range(self._max_retries):
+            try:
+                response = await self._llm.ainvoke(self._history)
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt < self._max_retries - 1:
+                    delay = min(self._retry_base_delay * (2**attempt), self._retry_max_delay)
+                    delay *= random.uniform(0.5, 1.5)  # noqa: S311
+                    logger.warning(
+                        "LLM call failed (attempt %d/%d), retrying in %.1fs: %s",
+                        attempt + 1,
+                        self._max_retries,
+                        delay,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+
+        if response is None:
+            logger.error("LLM call failed after %d attempts: %s", self._max_retries, last_exc)
+            self._history.append(AIMessage(content=_FALLBACK_RESPONSE))
+            return _FALLBACK_RESPONSE
+
         latency_ms = (time.perf_counter() - start) * 1000
 
         usage = getattr(response, "usage_metadata", None)
@@ -105,36 +136,41 @@ class ConversationEngine:
 
     async def _maybe_summarize(self) -> None:
         """If history exceeds token limit, summarize older messages."""
-        if self._estimate_tokens() <= self._max_context_tokens:
-            return
+        try:
+            if self._estimate_tokens() <= self._max_context_tokens:
+                return
 
-        non_system = self._history[1:]
-        if len(non_system) <= 4:
-            return
+            non_system = self._history[1:]
+            if len(non_system) <= 4:
+                return
 
-        split = len(non_system) // 2
-        older = non_system[:split]
-        newer = non_system[split:]
+            split = len(non_system) // 2
+            older = non_system[:split]
+            newer = non_system[split:]
 
-        lines: list[str] = []
-        for msg in older:
-            role = "Assistant" if isinstance(msg, AIMessage) else "Participant"
-            lines.append(f"{role}: {msg.content}")
-        conversation_text = "\n".join(lines)
+            lines: list[str] = []
+            for msg in older:
+                role = "Assistant" if isinstance(msg, AIMessage) else "Participant"
+                lines.append(f"{role}: {msg.content}")
+            conversation_text = "\n".join(lines)
 
-        logger.debug("Summarizing %d older messages (%d chars)", len(older), len(conversation_text))
+            logger.debug(
+                "Summarizing %d older messages (%d chars)", len(older), len(conversation_text)
+            )
 
-        prompt = SUMMARIZE_PROMPT.format(conversation_history=conversation_text)
+            prompt = SUMMARIZE_PROMPT.format(conversation_history=conversation_text)
 
-        start = time.perf_counter()
-        summary_response = await self._llm.ainvoke([HumanMessage(content=prompt)])
-        latency_ms = (time.perf_counter() - start) * 1000
-        logger.info("Summarization: %.0fms, model=%s", latency_ms, self._model_name)
+            start = time.perf_counter()
+            summary_response = await self._llm.ainvoke([HumanMessage(content=prompt)])
+            latency_ms = (time.perf_counter() - start) * 1000
+            logger.info("Summarization: %.0fms, model=%s", latency_ms, self._model_name)
 
-        summary_text = str(summary_response.content)
-        summary_msg = SystemMessage(content=f"Summary of earlier conversation:\n{summary_text}")
+            summary_text = str(summary_response.content)
+            summary_msg = SystemMessage(content=f"Summary of earlier conversation:\n{summary_text}")
 
-        self._history = [self._system_message, summary_msg, *newer]
+            self._history = [self._system_message, summary_msg, *newer]
+        except Exception:  # noqa: BLE001
+            logger.warning("Summarization failed, skipping", exc_info=True)
 
 
 async def conversation_stage(

--- a/src/call_operator/pipeline.py
+++ b/src/call_operator/pipeline.py
@@ -135,7 +135,24 @@ class Pipeline:
             results: list[Any] = await asyncio.gather(*self._tasks, return_exceptions=True)
             for task, result in zip(self._tasks, results, strict=True):
                 if isinstance(result, BaseException):
-                    logger.error("Stage %s failed: %s", task.get_name(), result)
+                    from call_operator.exceptions import AdapterError, CallOperatorError
+
+                    if isinstance(result, AdapterError):
+                        logger.error(
+                            "Stage %s: adapter error — %s: %s",
+                            task.get_name(),
+                            type(result).__name__,
+                            result,
+                        )
+                    elif isinstance(result, CallOperatorError):
+                        logger.error(
+                            "Stage %s: %s — %s",
+                            task.get_name(),
+                            type(result).__name__,
+                            result,
+                        )
+                    else:
+                        logger.error("Stage %s failed: %s", task.get_name(), result)
         finally:
             await self.stop()
 

--- a/src/call_operator/retry.py
+++ b/src/call_operator/retry.py
@@ -1,0 +1,132 @@
+"""Retry decorator with exponential backoff and circuit breaker."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import random
+import time
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_LLM_FALLBACK = "I'm having trouble responding right now."
+
+
+# ---------------------------------------------------------------------------
+# async_retry decorator
+# ---------------------------------------------------------------------------
+
+
+def async_retry(
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 30.0,
+    retryable_exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> Any:
+    """Decorator that retries an async function with exponential backoff and jitter.
+
+    Args:
+        max_retries: Maximum number of attempts (including the first).
+        base_delay: Base delay in seconds before first retry.
+        max_delay: Cap on the delay between retries.
+        retryable_exceptions: Exception types that trigger a retry.
+    """
+
+    def decorator(func: Any) -> Any:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            last_exc: Exception | None = None
+            for attempt in range(max_retries):
+                try:
+                    return await func(*args, **kwargs)
+                except retryable_exceptions as exc:
+                    last_exc = exc
+                    if attempt < max_retries - 1:
+                        delay = min(base_delay * (2**attempt), max_delay)
+                        delay *= random.uniform(0.5, 1.5)  # noqa: S311
+                        logger.warning(
+                            "Retry %d/%d for %s: %s (delay=%.1fs)",
+                            attempt + 1,
+                            max_retries,
+                            func.__qualname__,
+                            exc,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+            raise last_exc  # type: ignore[misc]
+
+        return wrapper
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker
+# ---------------------------------------------------------------------------
+
+_STATE_CLOSED = "CLOSED"
+_STATE_OPEN = "OPEN"
+_STATE_HALF_OPEN = "HALF_OPEN"
+
+
+class CircuitBreaker:
+    """Circuit breaker to prevent hammering a failing external API.
+
+    After *failure_threshold* consecutive failures the circuit opens,
+    rejecting calls for *cooldown_s* seconds.  After cooldown it enters
+    half-open state, allowing one call through.  Success closes it;
+    failure re-opens it.
+    """
+
+    def __init__(
+        self,
+        failure_threshold: int = 5,
+        cooldown_s: float = 60.0,
+    ) -> None:
+        self._threshold = failure_threshold
+        self._cooldown_s = cooldown_s
+        self._state = _STATE_CLOSED
+        self._consecutive_failures = 0
+        self._last_failure_time: float | None = None
+
+    @property
+    def is_open(self) -> bool:
+        """Return True if calls should be rejected."""
+        if self._state == _STATE_CLOSED:
+            return False
+
+        if self._state == _STATE_OPEN:
+            # Check if cooldown elapsed → transition to half-open
+            if (
+                self._last_failure_time is not None
+                and (time.monotonic() - self._last_failure_time) >= self._cooldown_s
+            ):
+                self._state = _STATE_HALF_OPEN
+                return False
+            return True
+
+        # HALF_OPEN: allow one call through
+        return False
+
+    def record_success(self) -> None:
+        """Record a successful call — reset to closed."""
+        self._consecutive_failures = 0
+        self._state = _STATE_CLOSED
+
+    def record_failure(self) -> None:
+        """Record a failed call — may open the circuit."""
+        self._consecutive_failures += 1
+        self._last_failure_time = time.monotonic()
+
+        if self._state == _STATE_HALF_OPEN:
+            self._state = _STATE_OPEN
+        elif self._consecutive_failures >= self._threshold:
+            self._state = _STATE_OPEN
+            logger.warning(
+                "Circuit breaker opened after %d consecutive failures",
+                self._consecutive_failures,
+            )

--- a/src/call_operator/stt/__init__.py
+++ b/src/call_operator/stt/__init__.py
@@ -44,7 +44,11 @@ async def stt_stage(
                 break
 
             chunks_processed += 1
-            transcript = await provider.transcribe(chunk)
+            try:
+                transcript = await provider.transcribe(chunk)
+            except Exception:  # noqa: BLE001
+                logger.exception("stt_stage: transcription failed, skipping chunk")
+                continue
             if transcript is not None:
                 transcripts_produced += 1
                 await out_queue.put(transcript)

--- a/src/call_operator/stt/deepgram_cloud.py
+++ b/src/call_operator/stt/deepgram_cloud.py
@@ -250,9 +250,12 @@ class DeepgramSTT(STTProvider):
             self._is_connected = False
 
     async def _reconnect(self) -> None:
-        """Attempt to reconnect with exponential backoff."""
+        """Attempt to reconnect with exponential backoff and jitter."""
+        import random
+
         for attempt in range(_MAX_RECONNECT_ATTEMPTS):
             delay = min(2**attempt * 0.5, 5.0)
+            delay *= random.uniform(0.5, 1.5)  # noqa: S311
             logger.warning(
                 "Deepgram reconnecting (attempt %d/%d, delay=%.1fs)",
                 attempt + 1,

--- a/src/call_operator/tts/elevenlabs_tts.py
+++ b/src/call_operator/tts/elevenlabs_tts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -65,25 +66,7 @@ class ElevenLabsTTS(TTSProvider):
         logger.debug("ElevenLabsTTS input: %s", text[:80])
         start_t = time.perf_counter()
 
-        from elevenlabs import VoiceSettings
-
-        response = self._client.text_to_speech.convert(
-            voice_id=self.voice,
-            text=text,
-            model_id=self.model_id,
-            voice_settings=VoiceSettings(
-                stability=self.stability,
-                similarity_boost=self.similarity_boost,
-                style=self.style,
-            ),
-            output_format="pcm_16000",
-        )
-
-        # Response is an async iterator of bytes chunks.
-        audio_parts: list[bytes] = []
-        async for chunk in response:
-            audio_parts.append(chunk)
-        pcm_data = b"".join(audio_parts)
+        pcm_data = await self._call_api_with_retry(text)
 
         latency_ms = (time.perf_counter() - start_t) * 1000
         duration_ms = len(pcm_data) / (2 * _TARGET_SAMPLE_RATE) * 1000
@@ -101,3 +84,36 @@ class ElevenLabsTTS(TTSProvider):
             timestamp=time.time(),
             duration_ms=duration_ms,
         )
+
+    async def _call_api_with_retry(self, text: str, max_retries: int = 3) -> bytes:
+        """Call ElevenLabs API with retry on transient failures."""
+        from elevenlabs import VoiceSettings
+
+        last_exc: Exception | None = None
+        for attempt in range(max_retries):
+            try:
+                response = self._client.text_to_speech.convert(
+                    voice_id=self.voice,
+                    text=text,
+                    model_id=self.model_id,
+                    voice_settings=VoiceSettings(
+                        stability=self.stability,
+                        similarity_boost=self.similarity_boost,
+                        style=self.style,
+                    ),
+                    output_format="pcm_16000",
+                )
+                audio_parts: list[bytes] = []
+                async for chunk in response:
+                    audio_parts.append(chunk)
+                return b"".join(audio_parts)
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt < max_retries - 1:
+                    delay = min(1.0 * (2**attempt), 30.0)
+                    logger.warning("ElevenLabs TTS retry %d/%d: %s", attempt + 1, max_retries, exc)
+                    await asyncio.sleep(delay)
+        from call_operator.exceptions import TTSError
+
+        msg = f"ElevenLabs TTS failed after {max_retries} attempts"
+        raise TTSError(msg) from last_exc

--- a/src/call_operator/tts/google_tts.py
+++ b/src/call_operator/tts/google_tts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -83,15 +84,7 @@ class GoogleTTS(TTSProvider):
             sample_rate_hertz=_TARGET_SAMPLE_RATE,
         )
 
-        response = await self._client.synthesize_speech(
-            input=synthesis_input,
-            voice=voice_params,
-            audio_config=audio_config,
-        )
-
-        # LINEAR16 responses include a 44-byte WAV header; strip it.
-        raw_audio: bytes = response.audio_content
-        pcm_data = raw_audio[_WAV_HEADER_SIZE:] if len(raw_audio) > _WAV_HEADER_SIZE else raw_audio
+        pcm_data = await self._call_api_with_retry(synthesis_input, voice_params, audio_config)
 
         latency_ms = (time.perf_counter() - start_t) * 1000
         duration_ms = len(pcm_data) / (2 * _TARGET_SAMPLE_RATE) * 1000
@@ -109,3 +102,30 @@ class GoogleTTS(TTSProvider):
             timestamp=time.time(),
             duration_ms=duration_ms,
         )
+
+    async def _call_api_with_retry(
+        self, synthesis_input: Any, voice_params: Any, audio_config: Any, max_retries: int = 3
+    ) -> bytes:
+        """Call Google Cloud TTS API with retry on transient failures."""
+        last_exc: Exception | None = None
+        for attempt in range(max_retries):
+            try:
+                response = await self._client.synthesize_speech(
+                    input=synthesis_input,
+                    voice=voice_params,
+                    audio_config=audio_config,
+                )
+                raw_audio: bytes = response.audio_content
+                if len(raw_audio) > _WAV_HEADER_SIZE:
+                    return raw_audio[_WAV_HEADER_SIZE:]
+                return raw_audio
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt < max_retries - 1:
+                    delay = min(1.0 * (2**attempt), 30.0)
+                    logger.warning("Google TTS retry %d/%d: %s", attempt + 1, max_retries, exc)
+                    await asyncio.sleep(delay)
+        from call_operator.exceptions import TTSError
+
+        msg = f"Google TTS failed after {max_retries} attempts"
+        raise TTSError(msg) from last_exc

--- a/src/call_operator/tts/openai_tts.py
+++ b/src/call_operator/tts/openai_tts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -70,14 +71,7 @@ class OpenAITTS(TTSProvider):
         logger.debug("OpenAITTS input: %s", text[:80])
         start_t = time.perf_counter()
 
-        response = await self._client.audio.speech.create(
-            model=self.model,
-            voice=self.voice,
-            input=text,
-            response_format="pcm",
-            speed=self.speed,
-        )
-        audio_data = response.read()
+        audio_data = await self._call_api_with_retry(text)
 
         pcm_16k = _downsample_24k_to_16k(audio_data)
         latency_ms = (time.perf_counter() - start_t) * 1000
@@ -96,6 +90,30 @@ class OpenAITTS(TTSProvider):
             timestamp=time.time(),
             duration_ms=duration_ms,
         )
+
+    async def _call_api_with_retry(self, text: str, max_retries: int = 3) -> bytes:
+        """Call OpenAI TTS API with retry on transient failures."""
+        last_exc: Exception | None = None
+        for attempt in range(max_retries):
+            try:
+                response = await self._client.audio.speech.create(
+                    model=self.model,
+                    voice=self.voice,
+                    input=text,
+                    response_format="pcm",
+                    speed=self.speed,
+                )
+                return response.read()  # type: ignore[no-any-return]
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt < max_retries - 1:
+                    delay = min(1.0 * (2**attempt), 30.0)
+                    logger.warning("OpenAI TTS retry %d/%d: %s", attempt + 1, max_retries, exc)
+                    await asyncio.sleep(delay)
+        from call_operator.exceptions import TTSError
+
+        msg = f"OpenAI TTS failed after {max_retries} attempts"
+        raise TTSError(msg) from last_exc
 
 
 def _downsample_24k_to_16k(pcm_24k: bytes) -> bytes:

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -137,6 +137,78 @@ class TestConversationEngine:
         )
         assert summary_found
 
+    async def test_llm_retry_then_succeed(self, mock_llm: AsyncMock) -> None:
+        mock_llm.ainvoke.side_effect = [
+            RuntimeError("transient"),
+            MagicMock(content="Recovered response"),
+        ]
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"LLM_PROVIDER": "openai", "OPENAI_API_KEY": "test-key"},
+            ),
+            patch("call_operator.llm.conversation.get_llm", return_value=mock_llm),
+            patch("call_operator.llm.conversation.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from call_operator.config import Settings
+
+            eng = ConversationEngine(Settings())
+
+        result = await eng.process_transcript("Hello")
+        assert result == "Recovered response"
+        assert mock_llm.ainvoke.call_count == 2
+
+    async def test_llm_retry_exhausted_returns_fallback(self, mock_llm: AsyncMock) -> None:
+        mock_llm.ainvoke.side_effect = RuntimeError("permanent failure")
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LLM_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "test-key",
+                    "RETRY_MAX_ATTEMPTS": "2",
+                },
+            ),
+            patch("call_operator.llm.conversation.get_llm", return_value=mock_llm),
+            patch("call_operator.llm.conversation.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from call_operator.config import Settings
+
+            eng = ConversationEngine(Settings())
+
+        result = await eng.process_transcript("Hello")
+        assert "trouble responding" in result
+        assert mock_llm.ainvoke.call_count == 2
+
+    async def test_summarization_failure_handled(self, mock_llm: AsyncMock) -> None:
+        """Summarization LLM failure should not crash process_transcript."""
+        # First call: normal response. Second call (summarization): fails.
+        mock_llm.ainvoke.side_effect = [
+            MagicMock(content="Response"),
+            RuntimeError("summarization failed"),
+        ]
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LLM_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "test-key",
+                    "LLM_MAX_CONTEXT_TOKENS": "10",
+                },
+            ),
+            patch("call_operator.llm.conversation.get_llm", return_value=mock_llm),
+        ):
+            from call_operator.config import Settings
+
+            eng = ConversationEngine(Settings())
+
+        # Should not raise despite summarization failure
+        result = await eng.process_transcript("A" * 200)
+        assert result == "Response"
+
 
 # ------------------------------------------------------------------
 # conversation_stage tests
@@ -163,7 +235,11 @@ class TestConversationStage:
 
     async def test_stage_continues_on_error(self, mock_settings: MagicMock) -> None:
         mock_llm = AsyncMock()
+        # With retry_max_attempts=3 (default), first transcript retries 3 times
+        # then returns fallback. Second transcript succeeds.
         mock_llm.ainvoke.side_effect = [
+            RuntimeError("LLM error"),
+            RuntimeError("LLM error"),
             RuntimeError("LLM error"),
             MagicMock(content="OK"),
         ]
@@ -175,9 +251,16 @@ class TestConversationStage:
         in_queue.put_nowait(Transcript(text="Second", speaker="user1"))
         in_queue.put_nowait(None)
 
-        with patch("call_operator.llm.conversation.get_llm", return_value=mock_llm):
+        with (
+            patch("call_operator.llm.conversation.get_llm", return_value=mock_llm),
+            patch("call_operator.llm.conversation.asyncio.sleep", new_callable=AsyncMock),
+        ):
             await conversation_stage(in_queue, out_queue, mock_settings)
 
+        # First transcript: fallback after 3 retries
+        fallback = out_queue.get_nowait()
+        assert "trouble responding" in fallback
+        # Second transcript: succeeds
         result = out_queue.get_nowait()
         assert result == "OK"
         assert out_queue.get_nowait() is None

--- a/tests/test_deepgram_cloud.py
+++ b/tests/test_deepgram_cloud.py
@@ -447,4 +447,8 @@ class TestDeepgramSTTReconnect:
         ):
             await stt._reconnect()
 
-        assert delays == [0.5, 1.0, 2.0]
+        # Delays use jitter (0.5-1.5x multiplier), so check ranges
+        assert len(delays) == 3
+        assert 0.25 <= delays[0] <= 0.75  # base 0.5 * jitter
+        assert 0.5 <= delays[1] <= 1.5  # base 1.0 * jitter
+        assert 1.0 <= delays[2] <= 3.0  # base 2.0 * jitter

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,133 @@
+"""Tests for async_retry decorator and CircuitBreaker."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from call_operator.retry import CircuitBreaker, async_retry
+
+# ------------------------------------------------------------------
+# async_retry tests
+# ------------------------------------------------------------------
+
+
+class TestAsyncRetry:
+    async def test_succeeds_first_try(self) -> None:
+        @async_retry(max_retries=3)
+        async def succeed() -> str:
+            return "ok"
+
+        assert await succeed() == "ok"
+
+    async def test_retries_then_succeeds(self) -> None:
+        call_count = 0
+
+        @async_retry(max_retries=3, base_delay=0.01)
+        async def flaky() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                msg = "transient"
+                raise RuntimeError(msg)
+            return "ok"
+
+        result = await flaky()
+        assert result == "ok"
+        assert call_count == 3
+
+    async def test_exhausts_retries(self) -> None:
+        @async_retry(max_retries=3, base_delay=0.01)
+        async def always_fail() -> str:
+            msg = "permanent"
+            raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="permanent"):
+            await always_fail()
+
+    async def test_only_retries_specified_exceptions(self) -> None:
+        call_count = 0
+
+        @async_retry(max_retries=3, base_delay=0.01, retryable_exceptions=(ValueError,))
+        async def wrong_error() -> str:
+            nonlocal call_count
+            call_count += 1
+            msg = "not retryable"
+            raise TypeError(msg)
+
+        with pytest.raises(TypeError, match="not retryable"):
+            await wrong_error()
+        assert call_count == 1  # no retry
+
+    async def test_backoff_calls_sleep(self) -> None:
+        call_count = 0
+
+        @async_retry(max_retries=3, base_delay=1.0)
+        async def fail_twice() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                msg = "transient"
+                raise RuntimeError(msg)
+            return "ok"
+
+        sleep_mock = AsyncMock()
+        with patch("call_operator.retry.asyncio.sleep", sleep_mock):
+            await fail_twice()
+
+        assert sleep_mock.call_count == 2  # slept before retry 2 and 3
+
+
+# ------------------------------------------------------------------
+# CircuitBreaker tests
+# ------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_starts_closed(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, cooldown_s=60.0)
+        assert cb.is_open is False
+
+    def test_opens_after_threshold(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, cooldown_s=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_open is False
+        cb.record_failure()  # 3rd failure
+        assert cb.is_open is True
+
+    def test_half_open_after_cooldown(self) -> None:
+        cb = CircuitBreaker(failure_threshold=2, cooldown_s=10.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_open is True
+
+        # Simulate cooldown elapsed
+        with patch("call_operator.retry.time.monotonic", return_value=time.monotonic() + 15.0):
+            assert cb.is_open is False  # transitioned to half-open
+
+    def test_success_closes_circuit(self) -> None:
+        cb = CircuitBreaker(failure_threshold=2, cooldown_s=10.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_open is True
+
+        # Simulate cooldown elapsed → half-open
+        with patch("call_operator.retry.time.monotonic", return_value=time.monotonic() + 15.0):
+            assert cb.is_open is False  # half-open allows one call
+            cb.record_success()
+        assert cb.is_open is False  # now closed
+
+    def test_failure_in_half_open_reopens(self) -> None:
+        cb = CircuitBreaker(failure_threshold=2, cooldown_s=10.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_open is True
+
+        # Simulate cooldown elapsed → half-open
+        with patch("call_operator.retry.time.monotonic", return_value=time.monotonic() + 15.0):
+            assert cb.is_open is False  # half-open
+            cb.record_failure()
+        assert cb.is_open is True  # re-opened


### PR DESCRIPTION
## Summary

- Add custom exception hierarchy, `async_retry` decorator, and `CircuitBreaker` class as resilience foundation
- Add retry with exponential backoff + jitter to LLM calls (with fallback message), all 3 TTS providers (raises `TTSError`), and Deepgram STT reconnect
- Add adapter auto-reconnection in `read_audio()`, per-chunk error handling in `stt_stage`, and structured error logging in pipeline

## Motivation

Resolves https://github.com/takeshi-su57/call-operator/issues/25

## Changes

### Foundation (new files)

**`exceptions.py`** — 10 custom exception classes:
```
CallOperatorError → AdapterError (Disconnected, Timeout)
                  → STTError (ProviderUnavailable)
                  → TTSError (ProviderUnavailable)
                  → LLMError (ProviderUnavailable)
                  → PipelineError (Shutdown)
```

**`retry.py`** — Two reusable resilience primitives:
- `async_retry(max_retries, base_delay, max_delay, retryable_exceptions)` — decorator with exponential backoff + jitter
- `CircuitBreaker(failure_threshold, cooldown_s)` — CLOSED/OPEN/HALF_OPEN state machine

### LLM retry (`conversation.py`)
- Inline retry loop around `self._llm.ainvoke()` with configurable attempts/delay
- On exhaustion: returns fallback message "I'm having trouble responding right now." (appended to history)
- `_maybe_summarize()` wrapped in try/except — failure skips summarization instead of crashing

### TTS retry (all 3 providers)
- `_call_api_with_retry()` method added to `OpenAITTS`, `ElevenLabsTTS`, `GoogleTTS`
- 3 retries with exponential backoff per API call
- Raises `TTSError` after exhaustion → caught by `tts_stage` which skips the failed synthesis

### Adapter reconnection (`google_meet.py`)
- `_reconnect()` method: disconnect → reconnect with exponential backoff (configurable max attempts)
- `read_audio()`: on browser error, attempts reconnect before returning None. On success, continues the read loop.
- Stores meeting URL for reconnection

### STT resilience
- `stt_stage`: added per-chunk try/except around `provider.transcribe()` (was unprotected — single failure would crash the stage)
- Deepgram: added jitter to reconnect backoff delays

### Pipeline structured logging (`pipeline.py`)
- Exception-type-aware error messages: `AdapterError` vs `CallOperatorError` vs generic exceptions
- Each logged with stage name + exception class name + message

### Config (6 new settings)
| Setting | Default | Description |
|---------|---------|-------------|
| `RETRY_MAX_ATTEMPTS` | 3 | Max retry attempts |
| `RETRY_BASE_DELAY` | 1.0 | Base backoff delay (seconds) |
| `RETRY_MAX_DELAY` | 30.0 | Max backoff cap (seconds) |
| `CIRCUIT_BREAKER_THRESHOLD` | 5 | Failures to open circuit |
| `CIRCUIT_BREAKER_COOLDOWN` | 60.0 | Cooldown before half-open (seconds) |
| `ADAPTER_MAX_RECONNECT_ATTEMPTS` | 3 | Max adapter reconnect tries |

## How to Test

### Unit tests
```bash
uv run pytest tests/test_retry.py tests/test_conversation.py -v   # 27 tests
uv run pytest -v   # 144 passed, 7 skipped
```

### Full suite
```bash
uv run pytest -v
```

## Deferred Items

Three items require architectural changes to stage functions and are deferred:
- **TTS provider fallback** — `tts_stage` would need multiple providers
- **STT cloud→local fallback** — `stt_stage` would need a backup provider
- **Circuit breaker integration** — class exists but not wired into provider call paths

The foundation (exceptions, circuit breaker, retry patterns) is in place for these.

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (10 new retry tests + 3 conversation tests + 1 updated deepgram test)
- [x] No new warnings or errors
- [x] `ruff check` passes
- [x] `mypy --strict` passes
- [x] All 144 tests pass
- [x] Updated issue doc with implementation notes
